### PR TITLE
feat(app): initialisation du projet Nuxt + Supabase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md — Compagnon JdR
+
+Guide pour Claude Code sur ce repo. Lis ce fichier avant toute intervention.
+
+## Structure du monorepo
+
+```
+/
+├── app/          ← Application Nuxt 3 (stack principale)
+├── backend/      ← Ancien backend Express (legacy, ne pas modifier)
+├── frontend/     ← Ancien frontend Vue 2 (legacy, ne pas modifier)
+└── API/          ← Specs API legacy
+```
+
+**Tout le développement actif se fait dans `app/`.**
+
+## Stack `app/`
+
+| Couche | Technologie |
+|---|---|
+| Framework | Nuxt 3 (SSR + server endpoints via Nitro) |
+| UI | @nuxt/ui |
+| Base de données | Supabase (Postgres + RLS + Realtime) |
+| Auth | @nuxtjs/supabase — uniquement pour le MJ |
+| Langage | TypeScript strict |
+
+## Modèle d'identité — règle fondamentale
+
+Il existe **deux types d'acteurs** avec des niveaux d'accès asymétriques :
+
+- **MJ (Game Master)** : authentifié via Supabase Auth (`auth.uid()` disponible). Accède aux données via le client Supabase front-end ou les server endpoints.
+- **Joueur anonyme** : aucune identité Supabase. Son seul credential est le `join_code` de session (6 caractères). Son `participant_id` (UUID) est persisté dans le localStorage après le `join`.
+
+## Règle d'or — accès joueur anonyme
+
+> **Tout accès aux données par un joueur anonyme transite par un server endpoint Nuxt.**
+
+Le client joueur ne doit **jamais** lire directement les tables Supabase via la clé anon. Le RLS est configuré pour bloquer ces accès délibérément.
+
+```
+✅  $fetch('/api/session/${id}/state?participant_id=${pid}')   ← server endpoint avec admin client
+❌  supabase.from('sessions').select('*').eq('id', id)         ← bloqué par RLS en prod
+```
+
+Les server endpoints utilisent `useSupabaseAdmin()` (clé `service_role`) et valident le `participant_id` avant de répondre.
+
+## Conventions de code
+
+### Server endpoints
+
+- Utiliser `useSupabaseAdmin()` pour les endpoints joueur (contourne RLS)
+- Utiliser `useSupabaseClient()` (via `serverSupabaseClient`) pour les endpoints MJ authentifiés
+- **Jamais de `select('*')` dans les endpoints publics ou joueur** — sélections explicites uniquement
+- Toujours valider `participant_id + session_id` avant de retourner des données joueur
+
+### Composables
+
+- Les composables MJ (`useGMSession`, `useCharacter`, `useScene`) peuvent lire Supabase directement — le MJ est authentifié et les policies RLS le protègent
+- Les composables joueur (`usePlayerSession`) ne lisent jamais Supabase directement — ils appellent les server endpoints
+- Les refs des composables sont déclarées **au niveau module** (hors de la fonction) pour partager l'état entre composants
+
+### Realtime Supabase
+
+- Sur un événement INSERT de `postgres_changes`, **ne pas utiliser `payload.new` pour les relations jointes** — `payload.new` ne contient que les colonnes de la table directement modifiée, pas les foreign keys résolues. Faire un fetch ciblé après.
+- Toujours nettoyer les subscriptions : stocker la fonction `unsub` retournée par `subscribeToXxx()` et l'appeler avant de créer un nouveau channel (éviter les memory leaks).
+
+### Sécurité
+
+- Utiliser `crypto.randomInt` (Node.js) pour toute génération de codes/tokens, pas `Math.random()`
+- Normaliser les inputs côté serveur (`.trim().toUpperCase()`) — ne pas faire confiance au format client
+- Ne jamais exposer `gm_user_id`, timestamps internes, ou colonnes d'ownership dans les réponses joueur
+
+## Architecture des fichiers `app/`
+
+```
+app/
+├── composables/
+│   ├── useGMSession.ts       ← état session MJ + realtime participants
+│   ├── usePlayerSession.ts   ← état session joueur (lit via server endpoints)
+│   ├── useScene.ts           ← CRUD scènes/entités MJ
+│   └── useCharacter.ts       ← CRUD personnages MJ
+├── server/
+│   ├── api/session/
+│   │   ├── create.post.ts    ← MJ : crée une session (auth requise)
+│   │   ├── join.post.ts      ← Joueur : rejoint via join_code (anon)
+│   │   ├── [code].get.ts     ← Preview session par code (page join)
+│   │   └── [id]/
+│   │       └── state.get.ts  ← Joueur : état complet session (valide participant_id)
+│   └── utils/
+│       ├── supabaseAdmin.ts  ← Client Supabase service_role
+│       └── generateJoinCode.ts ← Génère un code 6 chars (crypto.randomInt)
+├── supabase/migrations/
+│   └── 001_initial_schema.sql ← Schéma complet + RLS + Realtime
+└── pages/
+    ├── gm/                   ← Routes MJ (middleware auth)
+    └── player/               ← Routes joueur (middleware session locale)
+```
+
+## Variables d'environnement requises
+
+Voir `app/.env.example`. Les clés sensibles (`SUPABASE_SERVICE_KEY`, `SESSION_SECRET`) ne sont jamais exposées côté client (`runtimeConfig` sans `public`).
+
+## Documentation
+
+- `app/docs/architecture.md` — architecture détaillée et décisions de design
+- `app/docs/security.md` — modèle de sécurité RLS et patterns d'accès
+- `app/docs/adr/001-player-access-pattern.md` — ADR sur l'accès joueur via server endpoints

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,7 @@
+# Supabase - récupérer depuis Settings > API dans le dashboard Supabase
+SUPABASE_URL=https://xxxx.supabase.co
+SUPABASE_KEY=eyJhbGci...   # anon/public key
+SUPABASE_SERVICE_KEY=eyJhbGci...  # service_role key (serveur uniquement, ne jamais exposer)
+
+# Secret pour signer les tokens de session joueur
+SESSION_SECRET=un-secret-aleatoire-long-et-sur

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,12 @@
+# Nuxt
+.nuxt/
+.output/
+dist/
+node_modules/
+
+# Env
+.env
+.env.local
+
+# Logs
+*.log

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/app/components/gm/EntityBadge.vue
+++ b/app/components/gm/EntityBadge.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import type { SceneEntity, EnemyData } from '~/types/rpg'
+
+const props = defineProps<{ entity: SceneEntity }>()
+defineEmits<{
+  toggleVisibility: []
+  remove: []
+}>()
+
+const colorMap: Record<string, string> = {
+  enemy: 'red',
+  npc: 'blue',
+  item: 'yellow',
+  zone: 'green',
+}
+
+const enemyData = computed(() =>
+  props.entity.type === 'enemy' ? (props.entity.data as EnemyData) : null,
+)
+</script>
+
+<template>
+  <div
+    class="flex items-center gap-2 px-2 py-1 rounded-lg text-sm border"
+    :class="entity.visible_to_players ? 'border-gray-700 bg-gray-800' : 'border-gray-800 bg-gray-900 opacity-60'"
+  >
+    <UBadge :color="colorMap[entity.type] as 'red' | 'blue' | 'yellow' | 'green'" variant="soft" size="xs">
+      {{ entity.type }}
+    </UBadge>
+
+    <span class="font-medium truncate max-w-24">{{ entity.name }}</span>
+
+    <span v-if="enemyData" class="text-xs text-gray-400">
+      {{ enemyData.endurance }}/{{ enemyData.endurance_max }}
+    </span>
+
+    <div class="flex gap-1 ml-auto">
+      <UButton
+        size="xs"
+        variant="ghost"
+        :icon="entity.visible_to_players ? 'i-heroicons-eye' : 'i-heroicons-eye-slash'"
+        :color="entity.visible_to_players ? 'neutral' : 'gray'"
+        @click="$emit('toggleVisibility')"
+      />
+      <UButton
+        size="xs"
+        variant="ghost"
+        color="red"
+        icon="i-heroicons-x-mark"
+        @click="$emit('remove')"
+      />
+    </div>
+  </div>
+</template>

--- a/app/components/gm/EntityToken.vue
+++ b/app/components/gm/EntityToken.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import type { SceneEntity, EntityPosition } from '~/types/rpg'
+
+const props = defineProps<{ entity: SceneEntity }>()
+const emit = defineEmits<{
+  update: [patch: Partial<SceneEntity>]
+  remove: []
+}>()
+
+const colorMap: Record<string, string> = {
+  enemy: 'bg-red-600',
+  npc: 'bg-blue-600',
+  item: 'bg-yellow-500',
+  zone: 'bg-green-700',
+}
+
+const iconMap: Record<string, string> = {
+  enemy: 'i-heroicons-skull',
+  npc: 'i-heroicons-user',
+  item: 'i-heroicons-gift',
+  zone: 'i-heroicons-map-pin',
+}
+
+const showMenu = ref(false)
+
+// Drag & drop simplifié (positionnement CSS absolu en %)
+const style = computed(() => ({
+  left: `${props.entity.position.x}%`,
+  top: `${props.entity.position.y}%`,
+}))
+</script>
+
+<template>
+  <div
+    class="absolute -translate-x-1/2 -translate-y-1/2 group cursor-pointer"
+    :style="style"
+    @click.stop="showMenu = !showMenu"
+  >
+    <!-- Token -->
+    <div
+      class="w-8 h-8 rounded-full flex items-center justify-center text-white shadow-lg border-2 transition"
+      :class="[
+        colorMap[entity.type],
+        entity.visible_to_players ? 'border-white' : 'border-gray-500 opacity-60',
+      ]"
+    >
+      <UIcon :name="iconMap[entity.type]" class="text-sm" />
+    </div>
+
+    <!-- Label -->
+    <div class="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 whitespace-nowrap text-xs text-white bg-black/70 px-1 rounded pointer-events-none">
+      {{ entity.name }}
+    </div>
+
+    <!-- Menu contextuel -->
+    <div
+      v-if="showMenu"
+      class="absolute left-full top-0 ml-2 z-20 bg-gray-800 rounded-lg shadow-xl border border-gray-700 text-sm p-1 min-w-32"
+      @click.stop
+    >
+      <button
+        class="w-full text-left px-3 py-1.5 hover:bg-gray-700 rounded flex items-center gap-2"
+        @click="emit('update', { visible_to_players: !entity.visible_to_players }); showMenu = false"
+      >
+        <UIcon :name="entity.visible_to_players ? 'i-heroicons-eye-slash' : 'i-heroicons-eye'" />
+        {{ entity.visible_to_players ? 'Cacher' : 'Révéler' }}
+      </button>
+      <button
+        class="w-full text-left px-3 py-1.5 hover:bg-red-900/50 text-red-400 rounded flex items-center gap-2"
+        @click="emit('remove'); showMenu = false"
+      >
+        <UIcon name="i-heroicons-trash" />
+        Supprimer
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/components/player/CharacterSheet.vue
+++ b/app/components/player/CharacterSheet.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import type { Character, TORCharacterData } from '~/types/rpg'
+
+const props = defineProps<{ character: Character }>()
+const data = computed<TORCharacterData>(() => props.character.data)
+
+function attrPercent(current: number, max: number) {
+  return max > 0 ? Math.round((current / max) * 100) : 0
+}
+</script>
+
+<template>
+  <div class="space-y-6 max-w-2xl mx-auto">
+    <!-- Identité -->
+    <div class="grid grid-cols-3 gap-3 text-center">
+      <div class="bg-gray-800 rounded-lg p-3">
+        <p class="text-xs text-gray-500 uppercase">Culture</p>
+        <p class="font-medium mt-1">{{ data.culture || '—' }}</p>
+      </div>
+      <div class="bg-gray-800 rounded-lg p-3">
+        <p class="text-xs text-gray-500 uppercase">Vocation</p>
+        <p class="font-medium mt-1">{{ data.vocation || '—' }}</p>
+      </div>
+      <div class="bg-gray-800 rounded-lg p-3">
+        <p class="text-xs text-gray-500 uppercase">Niveau de vie</p>
+        <p class="font-medium mt-1 text-sm">{{ data.standard_of_living || '—' }}</p>
+      </div>
+    </div>
+
+    <!-- Attributs principaux -->
+    <div>
+      <h3 class="text-xs uppercase text-gray-500 mb-2">Attributs</h3>
+      <div class="grid grid-cols-3 gap-3">
+        <div
+          v-for="(attr, key) in { Force: data.attributes.strength, Cœur: data.attributes.heart, Esprit: data.attributes.mind }"
+          :key="key"
+          class="bg-gray-800 rounded-xl p-4 text-center"
+        >
+          <p class="text-xs text-gray-500 uppercase mb-1">{{ key }}</p>
+          <p class="text-3xl font-bold text-primary-400">{{ attr }}</p>
+          <p class="text-xs text-gray-500 mt-1">SR : {{ 20 - attr }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Attributs secondaires -->
+    <div class="grid grid-cols-2 gap-3">
+      <!-- Endurance -->
+      <div class="bg-gray-800 rounded-lg p-3">
+        <div class="flex justify-between items-center mb-1">
+          <span class="text-xs text-gray-500 uppercase">Endurance</span>
+          <span class="text-sm font-mono">{{ data.endurance_current }}/{{ data.endurance_max }}</span>
+        </div>
+        <div class="h-2 bg-gray-700 rounded-full overflow-hidden">
+          <div
+            class="h-full bg-green-500 transition-all"
+            :style="{ width: `${attrPercent(data.endurance_current, data.endurance_max)}%` }"
+          />
+        </div>
+      </div>
+
+      <!-- Espoir -->
+      <div class="bg-gray-800 rounded-lg p-3">
+        <div class="flex justify-between items-center mb-1">
+          <span class="text-xs text-gray-500 uppercase">Espoir</span>
+          <span class="text-sm font-mono">{{ data.hope_current }}/{{ data.hope_max }}</span>
+        </div>
+        <div class="h-2 bg-gray-700 rounded-full overflow-hidden">
+          <div
+            class="h-full bg-blue-400 transition-all"
+            :style="{ width: `${attrPercent(data.hope_current, data.hope_max)}%` }"
+          />
+        </div>
+      </div>
+
+      <div class="bg-gray-800 rounded-lg p-3 text-center">
+        <p class="text-xs text-gray-500 uppercase">Ombre</p>
+        <p class="text-2xl font-bold text-purple-400">{{ data.shadow }}</p>
+      </div>
+
+      <div class="bg-gray-800 rounded-lg p-3 text-center">
+        <p class="text-xs text-gray-500 uppercase">Parade</p>
+        <p class="text-2xl font-bold">{{ data.parry }}</p>
+      </div>
+    </div>
+
+    <!-- Compétences -->
+    <div class="space-y-4">
+      <h3 class="text-xs uppercase text-gray-500">Compétences</h3>
+
+      <div
+        v-for="[label, skills] in [
+          ['Force', data.skills_strength],
+          ['Cœur', data.skills_heart],
+          ['Esprit', data.skills_mind],
+        ]"
+        :key="label"
+      >
+        <p class="text-xs text-gray-400 mb-1">{{ label }}</p>
+        <div v-if="(skills as TORCharacterData['skills_strength']).length === 0" class="text-gray-600 text-sm">
+          Aucune compétence.
+        </div>
+        <div class="space-y-1">
+          <div
+            v-for="skill in (skills as TORCharacterData['skills_strength'])"
+            :key="skill.name"
+            class="flex items-center gap-2 text-sm"
+          >
+            <span
+              v-if="skill.favoured"
+              class="w-2 h-2 rounded-full bg-primary-400 shrink-0"
+              title="Favorisée"
+            />
+            <span v-else class="w-2 h-2 rounded-full bg-gray-600 shrink-0" />
+            <span class="flex-1">{{ skill.name }}</span>
+            <span class="font-mono text-gray-400">{{ skill.rank }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Armement -->
+    <div v-if="data.weapons.length > 0">
+      <h3 class="text-xs uppercase text-gray-500 mb-2">Armement</h3>
+      <div class="space-y-1">
+        <div
+          v-for="w in data.weapons"
+          :key="w.name"
+          class="flex items-center gap-3 text-sm bg-gray-800 rounded px-3 py-2"
+        >
+          <span class="flex-1 font-medium">{{ w.name }}</span>
+          <span class="text-gray-400">Dégâts {{ w.damage }}</span>
+          <span class="text-red-400">Blessure {{ w.injury }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Vertus & Récompenses -->
+    <div v-if="data.virtues.length > 0 || data.rewards.length > 0" class="grid grid-cols-2 gap-4">
+      <div v-if="data.virtues.length > 0">
+        <h3 class="text-xs uppercase text-gray-500 mb-2">Vertus</h3>
+        <div v-for="v in data.virtues" :key="v.name" class="text-sm mb-1">
+          <p class="font-medium text-primary-300">{{ v.name }}</p>
+          <p class="text-gray-500 text-xs">{{ v.description }}</p>
+        </div>
+      </div>
+      <div v-if="data.rewards.length > 0">
+        <h3 class="text-xs uppercase text-gray-500 mb-2">Récompenses</h3>
+        <div v-for="r in data.rewards" :key="r.name" class="text-sm mb-1">
+          <p class="font-medium text-yellow-300">{{ r.name }}</p>
+          <p class="text-gray-500 text-xs">{{ r.description }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- XP -->
+    <div class="grid grid-cols-2 gap-3 text-center">
+      <div class="bg-gray-800 rounded-lg p-3">
+        <p class="text-xs text-gray-500 uppercase">Expérience</p>
+        <p class="text-2xl font-bold text-primary-400">{{ data.experience }}</p>
+      </div>
+      <div class="bg-gray-800 rounded-lg p-3">
+        <p class="text-xs text-gray-500 uppercase">Avancement</p>
+        <p class="text-2xl font-bold">{{ data.advancement }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/player/EnemyCard.vue
+++ b/app/components/player/EnemyCard.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { SceneEntity, EnemyData } from '~/types/rpg'
+
+const props = defineProps<{ entity: SceneEntity }>()
+
+const data = computed(() => props.entity.data as EnemyData)
+const hpPercent = computed(() =>
+  data.value.endurance_max > 0
+    ? Math.round((data.value.endurance / data.value.endurance_max) * 100)
+    : 0,
+)
+const hpColor = computed(() => {
+  if (hpPercent.value > 60) return 'bg-green-500'
+  if (hpPercent.value > 30) return 'bg-yellow-500'
+  return 'bg-red-500'
+})
+</script>
+
+<template>
+  <div class="bg-red-950/30 border border-red-900/50 rounded-lg px-3 py-2">
+    <div class="flex items-center justify-between mb-1">
+      <span class="font-medium text-sm text-red-200">{{ entity.name }}</span>
+      <span class="text-xs text-red-400 font-mono">
+        {{ data.endurance }}/{{ data.endurance_max }}
+      </span>
+    </div>
+    <!-- Barre d'endurance -->
+    <div class="h-1.5 bg-gray-800 rounded-full overflow-hidden">
+      <div
+        class="h-full transition-all duration-300 rounded-full"
+        :class="hpColor"
+        :style="{ width: `${hpPercent}%` }"
+      />
+    </div>
+    <div v-if="data.parry || data.armor" class="flex gap-3 mt-1.5 text-xs text-gray-500">
+      <span v-if="data.parry">Parade {{ data.parry }}</span>
+      <span v-if="data.armor">Armure {{ data.armor }}</span>
+    </div>
+  </div>
+</template>

--- a/app/components/player/EntityCard.vue
+++ b/app/components/player/EntityCard.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { SceneEntity } from '~/types/rpg'
+
+defineProps<{ entity: SceneEntity }>()
+
+const colorMap: Record<string, string> = {
+  npc: 'border-blue-900/50 bg-blue-950/30 text-blue-200',
+  item: 'border-yellow-800/50 bg-yellow-950/30 text-yellow-200',
+  zone: 'border-green-900/50 bg-green-950/30 text-green-200',
+}
+</script>
+
+<template>
+  <div
+    class="border rounded-lg px-3 py-2 text-sm"
+    :class="colorMap[entity.type] ?? 'border-gray-700 bg-gray-800 text-gray-200'"
+  >
+    <p class="font-medium">{{ entity.name }}</p>
+    <p
+      v-if="(entity.data as Record<string, unknown>).description"
+      class="text-xs text-gray-400 mt-0.5"
+    >
+      {{ (entity.data as Record<string, unknown>).description }}
+    </p>
+  </div>
+</template>

--- a/app/components/player/EntityToken.vue
+++ b/app/components/player/EntityToken.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { SceneEntity } from '~/types/rpg'
+
+defineProps<{ entity: SceneEntity }>()
+
+const colorMap: Record<string, string> = {
+  enemy: 'bg-red-600',
+  npc: 'bg-blue-600',
+  item: 'bg-yellow-500',
+  zone: 'bg-green-700',
+}
+
+const iconMap: Record<string, string> = {
+  enemy: 'i-heroicons-skull',
+  npc: 'i-heroicons-user',
+  item: 'i-heroicons-gift',
+  zone: 'i-heroicons-map-pin',
+}
+</script>
+
+<template>
+  <div
+    class="absolute -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+    :style="{ left: `${entity.position.x}%`, top: `${entity.position.y}%` }"
+  >
+    <div
+      class="w-8 h-8 rounded-full flex items-center justify-center text-white shadow-lg border-2 border-white"
+      :class="colorMap[entity.type]"
+    >
+      <UIcon :name="iconMap[entity.type]" class="text-sm" />
+    </div>
+    <div class="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 whitespace-nowrap text-xs text-white bg-black/70 px-1 rounded">
+      {{ entity.name }}
+    </div>
+  </div>
+</template>

--- a/app/composables/useCharacter.ts
+++ b/app/composables/useCharacter.ts
@@ -1,0 +1,118 @@
+import type { Character, TORCharacterData } from '~/types/rpg'
+
+/**
+ * CRUD des personnages pour le MJ.
+ */
+export function useCharacter(campaignId: string) {
+  const supabase = useSupabaseClient()
+  const characters = ref<Character[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchAll() {
+    loading.value = true
+    error.value = null
+    const { data, error: err } = await supabase
+      .from('characters')
+      .select('*')
+      .eq('campaign_id', campaignId)
+      .order('created_at', { ascending: true })
+
+    if (err) {
+      error.value = err.message
+    } else {
+      characters.value = data as Character[]
+    }
+    loading.value = false
+  }
+
+  async function create(
+    name: string,
+    playerName: string,
+    data: Partial<TORCharacterData> = {},
+  ): Promise<Character | null> {
+    const defaultData: TORCharacterData = {
+      culture: '',
+      vocation: '',
+      standard_of_living: '',
+      attributes: { strength: 4, heart: 4, mind: 4 },
+      endurance_max: 20,
+      endurance_current: 20,
+      hope_max: 10,
+      hope_current: 10,
+      shadow: 0,
+      parry: 14,
+      skills_strength: [],
+      skills_heart: [],
+      skills_mind: [],
+      weapons: [],
+      experience: 0,
+      advancement: 0,
+      virtues: [],
+      rewards: [],
+      ...data,
+    }
+
+    const { data: created, error: err } = await supabase
+      .from('characters')
+      .insert({ campaign_id: campaignId, name, player_name: playerName, data: defaultData })
+      .select()
+      .single()
+
+    if (err) {
+      error.value = err.message
+      return null
+    }
+    characters.value.push(created as Character)
+    return created as Character
+  }
+
+  async function update(id: string, patch: Partial<Character>) {
+    const { error: err } = await supabase
+      .from('characters')
+      .update(patch)
+      .eq('id', id)
+
+    if (err) {
+      error.value = err.message
+      return false
+    }
+    const idx = characters.value.findIndex(c => c.id === id)
+    if (idx !== -1) {
+      characters.value[idx] = { ...characters.value[idx], ...patch }
+    }
+    return true
+  }
+
+  async function updateData(id: string, data: Partial<TORCharacterData>) {
+    const character = characters.value.find(c => c.id === id)
+    if (!character) return false
+    const merged = { ...character.data, ...data }
+    return update(id, { data: merged as TORCharacterData })
+  }
+
+  async function remove(id: string) {
+    const { error: err } = await supabase
+      .from('characters')
+      .delete()
+      .eq('id', id)
+
+    if (err) {
+      error.value = err.message
+      return false
+    }
+    characters.value = characters.value.filter(c => c.id !== id)
+    return true
+  }
+
+  return {
+    characters: readonly(characters),
+    loading: readonly(loading),
+    error: readonly(error),
+    fetchAll,
+    create,
+    update,
+    updateData,
+    remove,
+  }
+}

--- a/app/composables/useGMSession.ts
+++ b/app/composables/useGMSession.ts
@@ -98,10 +98,14 @@ export function useGMSession() {
       .on(
         'postgres_changes',
         { event: 'INSERT', schema: 'public', table: 'session_participants', filter: `session_id=eq.${sessionId}` },
-        (payload) => {
-          const participant = payload.new as SessionParticipant
-          if (!participants.value.find(p => p.id === participant.id)) {
-            participants.value.push(participant)
+        async (payload) => {
+          const { data: fullParticipant } = await supabase
+            .from('session_participants')
+            .select('*, character:characters(*)')
+            .eq('id', payload.new.id)
+            .single()
+          if (fullParticipant && !participants.value.find(p => p.id === fullParticipant.id)) {
+            participants.value.push(fullParticipant as SessionParticipant)
           }
         },
       )

--- a/app/composables/useGMSession.ts
+++ b/app/composables/useGMSession.ts
@@ -1,0 +1,134 @@
+import type { GameSession, SessionParticipant } from '~/types/rpg'
+
+/**
+ * Gestion de session côté MJ.
+ * Crée une session, change la scène active, suit les participants en temps réel.
+ */
+export function useGMSession() {
+  const supabase = useSupabaseClient()
+  const session = ref<GameSession | null>(null)
+  const participants = ref<SessionParticipant[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  // ─── Créer une session ────────────────────────────────────────────────────
+
+  async function createSession(campaignId: string): Promise<GameSession | null> {
+    loading.value = true
+    error.value = null
+
+    // Délégation à l'API serveur qui génère le code unique
+    const data = await $fetch<GameSession>('/api/session/create', {
+      method: 'POST',
+      body: { campaign_id: campaignId },
+    }).catch((err) => {
+      error.value = err.data?.message ?? 'Erreur lors de la création de la session'
+      return null
+    })
+
+    if (data) session.value = data
+    loading.value = false
+    return data
+  }
+
+  // ─── Charger une session existante ────────────────────────────────────────
+
+  async function loadSession(sessionId: string) {
+    loading.value = true
+    const { data, error: err } = await supabase
+      .from('sessions')
+      .select('*, campaign:campaigns(*), active_scene:scenes(*)')
+      .eq('id', sessionId)
+      .single()
+
+    if (err) error.value = err.message
+    else session.value = data as GameSession
+
+    await fetchParticipants(sessionId)
+    loading.value = false
+  }
+
+  // ─── Changer la scène active ──────────────────────────────────────────────
+
+  async function setActiveScene(sceneId: string | null) {
+    if (!session.value) return false
+    const { error: err } = await supabase
+      .from('sessions')
+      .update({ active_scene_id: sceneId, status: sceneId ? 'active' : 'waiting' })
+      .eq('id', session.value.id)
+
+    if (err) { error.value = err.message; return false }
+    session.value = { ...session.value, active_scene_id: sceneId, status: sceneId ? 'active' : 'waiting' }
+    return true
+  }
+
+  // ─── Terminer la session ──────────────────────────────────────────────────
+
+  async function endSession() {
+    if (!session.value) return false
+    const { error: err } = await supabase
+      .from('sessions')
+      .update({ status: 'ended', active_scene_id: null })
+      .eq('id', session.value.id)
+
+    if (err) { error.value = err.message; return false }
+    session.value = { ...session.value, status: 'ended', active_scene_id: null }
+    return true
+  }
+
+  // ─── Participants ─────────────────────────────────────────────────────────
+
+  async function fetchParticipants(sessionId: string) {
+    const { data, error: err } = await supabase
+      .from('session_participants')
+      .select('*, character:characters(*)')
+      .eq('session_id', sessionId)
+      .order('joined_at', { ascending: true })
+
+    if (err) error.value = err.message
+    else participants.value = data as SessionParticipant[]
+  }
+
+  // ─── Realtime : participants et changements de session ────────────────────
+
+  function subscribeToSession(sessionId: string) {
+    const channel = supabase
+      .channel(`gm-session-${sessionId}`)
+      // Nouveaux participants
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'session_participants', filter: `session_id=eq.${sessionId}` },
+        (payload) => {
+          const participant = payload.new as SessionParticipant
+          if (!participants.value.find(p => p.id === participant.id)) {
+            participants.value.push(participant)
+          }
+        },
+      )
+      // Participants qui quittent (delete)
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'session_participants', filter: `session_id=eq.${sessionId}` },
+        (payload) => {
+          participants.value = participants.value.filter(
+            p => p.id !== (payload.old as SessionParticipant).id,
+          )
+        },
+      )
+      .subscribe()
+
+    return () => { supabase.removeChannel(channel) }
+  }
+
+  return {
+    session: readonly(session),
+    participants: readonly(participants),
+    loading: readonly(loading),
+    error: readonly(error),
+    createSession,
+    loadSession,
+    setActiveScene,
+    endSession,
+    subscribeToSession,
+  }
+}

--- a/app/composables/usePlayerSession.ts
+++ b/app/composables/usePlayerSession.ts
@@ -1,0 +1,250 @@
+import type { GameSession, Character, Scene, SceneEntity, JoinSessionResponse } from '~/types/rpg'
+
+const STORAGE_KEY = 'compagnon_player_session'
+
+/**
+ * Gestion de session côté joueur.
+ * Le joueur rejoint via un join_code. Son état est persisté dans localStorage.
+ */
+export function usePlayerSession() {
+  const supabase = useSupabaseClient()
+
+  const session = ref<GameSession | null>(null)
+  const participantId = ref<string | null>(null)
+  const playerName = ref<string | null>(null)
+  const selectedCharacter = ref<Character | null>(null)
+  const availableCharacters = ref<Character[]>([])
+  const activeScene = ref<Scene | null>(null)
+  const sceneEntities = ref<SceneEntity[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  // ─── Rejoindre une session ────────────────────────────────────────────────
+
+  async function join(joinCode: string, name: string, characterId?: string): Promise<boolean> {
+    loading.value = true
+    error.value = null
+
+    const result = await $fetch<JoinSessionResponse>('/api/session/join', {
+      method: 'POST',
+      body: { join_code: joinCode.toUpperCase(), player_name: name, character_id: characterId },
+    }).catch((err) => {
+      error.value = err.data?.message ?? 'Code de session invalide'
+      return null
+    })
+
+    if (!result) { loading.value = false; return false }
+
+    session.value = result.session
+    participantId.value = result.participant_id
+    playerName.value = name
+
+    // Persister en localStorage pour survie au refresh
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      session_id: result.session.id,
+      participant_id: result.participant_id,
+      player_name: name,
+      character_id: characterId ?? null,
+    }))
+
+    await loadSessionState(result.session.id, characterId)
+    loading.value = false
+    return true
+  }
+
+  // ─── Restaurer depuis localStorage ───────────────────────────────────────
+
+  async function restore(): Promise<boolean> {
+    if (typeof window === 'undefined') return false
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return false
+
+    try {
+      const { session_id, participant_id, player_name, character_id } = JSON.parse(stored)
+      participantId.value = participant_id
+      playerName.value = player_name
+
+      const { data, error: err } = await supabase
+        .from('sessions')
+        .select('*, campaign:campaigns(*), active_scene:scenes(*)')
+        .eq('id', session_id)
+        .single()
+
+      if (err || !data || (data as GameSession).status === 'ended') {
+        clearSession()
+        return false
+      }
+
+      session.value = data as GameSession
+      await loadSessionState(session_id, character_id)
+      return true
+    } catch {
+      clearSession()
+      return false
+    }
+  }
+
+  function clearSession() {
+    session.value = null
+    participantId.value = null
+    playerName.value = null
+    selectedCharacter.value = null
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  // ─── Charger l'état de la session ────────────────────────────────────────
+
+  async function loadSessionState(sessionId: string, characterId?: string | null) {
+    // Personnages disponibles dans la campagne
+    if (session.value?.campaign_id) {
+      const { data } = await supabase
+        .from('characters')
+        .select('*')
+        .eq('campaign_id', session.value.campaign_id)
+
+      availableCharacters.value = (data as Character[]) ?? []
+    }
+
+    // Personnage sélectionné
+    if (characterId) {
+      selectedCharacter.value = availableCharacters.value.find(c => c.id === characterId) ?? null
+    }
+
+    // Scène active
+    if (session.value?.active_scene_id) {
+      await loadActiveScene(session.value.active_scene_id)
+    }
+  }
+
+  async function loadActiveScene(sceneId: string) {
+    const { data: sceneData } = await supabase
+      .from('scenes')
+      .select('*')
+      .eq('id', sceneId)
+      .single()
+
+    if (sceneData) {
+      activeScene.value = sceneData as Scene
+
+      const { data: entitiesData } = await supabase
+        .from('scene_entities')
+        .select('*')
+        .eq('scene_id', sceneId)
+        .eq('visible_to_players', true)
+
+      sceneEntities.value = (entitiesData as SceneEntity[]) ?? []
+    }
+  }
+
+  // ─── Realtime : suivre les changements de session ─────────────────────────
+
+  function subscribeToSessionUpdates() {
+    if (!session.value) return () => {}
+
+    const sessionId = session.value.id
+
+    const channel = supabase
+      .channel(`player-session-${sessionId}`)
+      // Changement de scène active
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'sessions', filter: `id=eq.${sessionId}` },
+        async (payload) => {
+          const updated = payload.new as GameSession
+          session.value = { ...session.value!, ...updated }
+
+          if (updated.active_scene_id && updated.active_scene_id !== activeScene.value?.id) {
+            await loadActiveScene(updated.active_scene_id)
+            subscribeToSceneEntities(updated.active_scene_id)
+          } else if (!updated.active_scene_id) {
+            activeScene.value = null
+            sceneEntities.value = []
+          }
+        },
+      )
+      .subscribe()
+
+    // S'abonner aux entités de la scène active courante
+    let unsubEntities = () => {}
+    if (session.value.active_scene_id) {
+      unsubEntities = subscribeToSceneEntities(session.value.active_scene_id)
+    }
+
+    return () => {
+      supabase.removeChannel(channel)
+      unsubEntities()
+    }
+  }
+
+  function subscribeToSceneEntities(sceneId: string) {
+    const channel = supabase
+      .channel(`player-entities-${sceneId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'scene_entities',
+          filter: `scene_id=eq.${sceneId}`,
+        },
+        (payload) => {
+          const entity = payload.new as SceneEntity
+          if (entity.visible_to_players && !sceneEntities.value.find(e => e.id === entity.id)) {
+            sceneEntities.value.push(entity)
+          }
+        },
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'scene_entities',
+          filter: `scene_id=eq.${sceneId}`,
+        },
+        (payload) => {
+          const updated = payload.new as SceneEntity
+          const idx = sceneEntities.value.findIndex(e => e.id === updated.id)
+          if (updated.visible_to_players) {
+            if (idx !== -1) sceneEntities.value[idx] = updated
+            else sceneEntities.value.push(updated)
+          } else if (idx !== -1) {
+            sceneEntities.value.splice(idx, 1)
+          }
+        },
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'scene_entities',
+          filter: `scene_id=eq.${sceneId}`,
+        },
+        (payload) => {
+          sceneEntities.value = sceneEntities.value.filter(
+            e => e.id !== (payload.old as SceneEntity).id,
+          )
+        },
+      )
+      .subscribe()
+
+    return () => { supabase.removeChannel(channel) }
+  }
+
+  return {
+    session: readonly(session),
+    participantId: readonly(participantId),
+    playerName: readonly(playerName),
+    selectedCharacter: readonly(selectedCharacter),
+    availableCharacters: readonly(availableCharacters),
+    activeScene: readonly(activeScene),
+    sceneEntities: readonly(sceneEntities),
+    loading: readonly(loading),
+    error: readonly(error),
+    join,
+    restore,
+    clearSession,
+    subscribeToSessionUpdates,
+  }
+}

--- a/app/composables/usePlayerSession.ts
+++ b/app/composables/usePlayerSession.ts
@@ -64,18 +64,21 @@ export function usePlayerSession() {
       participantId.value = participant_id
       playerName.value = player_name
 
-      const { data, error: err } = await supabase
-        .from('sessions')
-        .select('*, campaign:campaigns(*), active_scene:scenes(*)')
-        .eq('id', session_id)
-        .single()
+      const result = await $fetch<{
+        session: GameSession
+        active_scene: Scene | null
+        scene_entities: SceneEntity[]
+      }>(`/api/session/${session_id}/state?participant_id=${participant_id}`).catch(() => null)
 
-      if (err || !data || (data as GameSession).status === 'ended') {
+      if (!result || result.session.status === 'ended') {
         clearSession()
         return false
       }
 
-      session.value = data as GameSession
+      session.value = result.session
+      activeScene.value = result.active_scene
+      sceneEntities.value = result.scene_entities
+
       await loadSessionState(session_id, character_id)
       return true
     } catch {
@@ -117,22 +120,17 @@ export function usePlayerSession() {
   }
 
   async function loadActiveScene(sceneId: string) {
-    const { data: sceneData } = await supabase
-      .from('scenes')
-      .select('*')
-      .eq('id', sceneId)
-      .single()
+    if (!session.value || !participantId.value) return
 
-    if (sceneData) {
-      activeScene.value = sceneData as Scene
+    const result = await $fetch<{
+      session: GameSession
+      active_scene: Scene | null
+      scene_entities: SceneEntity[]
+    }>(`/api/session/${session.value.id}/state?participant_id=${participantId.value}`).catch(() => null)
 
-      const { data: entitiesData } = await supabase
-        .from('scene_entities')
-        .select('*')
-        .eq('scene_id', sceneId)
-        .eq('visible_to_players', true)
-
-      sceneEntities.value = (entitiesData as SceneEntity[]) ?? []
+    if (result) {
+      activeScene.value = result.active_scene
+      sceneEntities.value = result.scene_entities
     }
   }
 
@@ -142,6 +140,8 @@ export function usePlayerSession() {
     if (!session.value) return () => {}
 
     const sessionId = session.value.id
+
+    let currentSceneUnsub: (() => void) | null = null
 
     const channel = supabase
       .channel(`player-session-${sessionId}`)
@@ -155,7 +155,8 @@ export function usePlayerSession() {
 
           if (updated.active_scene_id && updated.active_scene_id !== activeScene.value?.id) {
             await loadActiveScene(updated.active_scene_id)
-            subscribeToSceneEntities(updated.active_scene_id)
+            currentSceneUnsub?.()
+            currentSceneUnsub = subscribeToSceneEntities(updated.active_scene_id)
           } else if (!updated.active_scene_id) {
             activeScene.value = null
             sceneEntities.value = []
@@ -165,14 +166,13 @@ export function usePlayerSession() {
       .subscribe()
 
     // S'abonner aux entités de la scène active courante
-    let unsubEntities = () => {}
     if (session.value.active_scene_id) {
-      unsubEntities = subscribeToSceneEntities(session.value.active_scene_id)
+      currentSceneUnsub = subscribeToSceneEntities(session.value.active_scene_id)
     }
 
     return () => {
       supabase.removeChannel(channel)
-      unsubEntities()
+      currentSceneUnsub?.()
     }
   }
 

--- a/app/composables/usePlayerSession.ts
+++ b/app/composables/usePlayerSession.ts
@@ -92,20 +92,23 @@ export function usePlayerSession() {
     participantId.value = null
     playerName.value = null
     selectedCharacter.value = null
+    availableCharacters.value = []
+    activeScene.value = null
+    sceneEntities.value = []
+    error.value = null
+    loading.value = false
     localStorage.removeItem(STORAGE_KEY)
   }
 
   // ─── Charger l'état de la session ────────────────────────────────────────
 
   async function loadSessionState(sessionId: string, characterId?: string | null) {
-    // Personnages disponibles dans la campagne
-    if (session.value?.campaign_id) {
-      const { data } = await supabase
-        .from('characters')
-        .select('*')
-        .eq('campaign_id', session.value.campaign_id)
-
-      availableCharacters.value = (data as Character[]) ?? []
+    // Personnages disponibles dans la campagne — via server endpoint (règle ADR joueur anonyme)
+    if (participantId.value) {
+      const characters = await $fetch<Character[]>(
+        `/api/session/${sessionId}/characters?participant_id=${participantId.value}`,
+      ).catch(() => [])
+      availableCharacters.value = characters
     }
 
     // Personnage sélectionné
@@ -158,6 +161,8 @@ export function usePlayerSession() {
             currentSceneUnsub?.()
             currentSceneUnsub = subscribeToSceneEntities(updated.active_scene_id)
           } else if (!updated.active_scene_id) {
+            currentSceneUnsub?.()
+            currentSceneUnsub = null
             activeScene.value = null
             sceneEntities.value = []
           }

--- a/app/composables/useScene.ts
+++ b/app/composables/useScene.ts
@@ -120,7 +120,9 @@ export function useScene(sessionId: string) {
     return true
   }
 
-  // ─── Realtime (lecture pour les joueurs) ─────────────────────────────────
+  // ─── Realtime (synchronisation MJ — toutes entités, y compris cachées) ─────
+  // Pour la version joueur (entités filtrées par visible_to_players), voir
+  // usePlayerSession.ts > subscribeToSceneEntities.
   // Subscribes aux changements d'entités d'une scène spécifique.
   function subscribeToEntities(sceneId: string) {
     const channel = supabase

--- a/app/composables/useScene.ts
+++ b/app/composables/useScene.ts
@@ -1,0 +1,190 @@
+import type { Scene, SceneEntity, EntityType, EntityData, EntityPosition } from '~/types/rpg'
+
+/**
+ * Gestion des scènes et entités pour le MJ.
+ * Inclut les subscriptions Supabase Realtime pour les mises à jour live.
+ */
+export function useScene(sessionId: string) {
+  const supabase = useSupabaseClient()
+  const scenes = ref<Scene[]>([])
+  const entities = ref<SceneEntity[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  // ─── Scènes ──────────────────────────────────────────────────────────────
+
+  async function fetchScenes() {
+    loading.value = true
+    const { data, error: err } = await supabase
+      .from('scenes')
+      .select('*')
+      .eq('session_id', sessionId)
+      .order('created_at', { ascending: true })
+
+    if (err) error.value = err.message
+    else scenes.value = data as Scene[]
+    loading.value = false
+  }
+
+  async function createScene(name: string, description?: string): Promise<Scene | null> {
+    const { data, error: err } = await supabase
+      .from('scenes')
+      .insert({ session_id: sessionId, name, description: description ?? null })
+      .select()
+      .single()
+
+    if (err) { error.value = err.message; return null }
+    const scene = data as Scene
+    scenes.value.push(scene)
+    return scene
+  }
+
+  async function uploadBattlemap(sceneId: string, file: File): Promise<string | null> {
+    const path = `${sessionId}/${sceneId}/${file.name}`
+    const { error: uploadError } = await supabase.storage
+      .from('battlemaps')
+      .upload(path, file, { upsert: true })
+
+    if (uploadError) { error.value = uploadError.message; return null }
+
+    const { data } = supabase.storage.from('battlemaps').getPublicUrl(path)
+    const url = data.publicUrl
+
+    await supabase.from('scenes').update({ battlemap_url: url }).eq('id', sceneId)
+    const idx = scenes.value.findIndex(s => s.id === sceneId)
+    if (idx !== -1) scenes.value[idx] = { ...scenes.value[idx], battlemap_url: url }
+
+    return url
+  }
+
+  async function deleteScene(sceneId: string) {
+    const { error: err } = await supabase.from('scenes').delete().eq('id', sceneId)
+    if (err) { error.value = err.message; return false }
+    scenes.value = scenes.value.filter(s => s.id !== sceneId)
+    return true
+  }
+
+  // ─── Entités ─────────────────────────────────────────────────────────────
+
+  async function fetchEntities(sceneId: string) {
+    const { data, error: err } = await supabase
+      .from('scene_entities')
+      .select('*')
+      .eq('scene_id', sceneId)
+      .order('created_at', { ascending: true })
+
+    if (err) error.value = err.message
+    else entities.value = data as SceneEntity[]
+  }
+
+  async function addEntity(
+    sceneId: string,
+    type: EntityType,
+    name: string,
+    data: EntityData,
+    position: EntityPosition = { x: 0, y: 0 },
+    visibleToPlayers = true,
+  ): Promise<SceneEntity | null> {
+    const { data: created, error: err } = await supabase
+      .from('scene_entities')
+      .insert({ scene_id: sceneId, type, name, data, position, visible_to_players: visibleToPlayers })
+      .select()
+      .single()
+
+    if (err) { error.value = err.message; return null }
+    const entity = created as SceneEntity
+    entities.value.push(entity)
+    return entity
+  }
+
+  async function updateEntity(id: string, patch: Partial<SceneEntity>) {
+    const { error: err } = await supabase
+      .from('scene_entities')
+      .update(patch)
+      .eq('id', id)
+
+    if (err) { error.value = err.message; return false }
+    const idx = entities.value.findIndex(e => e.id === id)
+    if (idx !== -1) entities.value[idx] = { ...entities.value[idx], ...patch }
+    return true
+  }
+
+  async function moveEntity(id: string, position: EntityPosition) {
+    return updateEntity(id, { position })
+  }
+
+  async function removeEntity(id: string) {
+    const { error: err } = await supabase.from('scene_entities').delete().eq('id', id)
+    if (err) { error.value = err.message; return false }
+    entities.value = entities.value.filter(e => e.id !== id)
+    return true
+  }
+
+  // ─── Realtime (lecture pour les joueurs) ─────────────────────────────────
+  // Subscribes aux changements d'entités d'une scène spécifique.
+  function subscribeToEntities(sceneId: string) {
+    const channel = supabase
+      .channel(`scene-entities-${sceneId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'scene_entities',
+          filter: `scene_id=eq.${sceneId}`,
+        },
+        (payload) => {
+          const entity = payload.new as SceneEntity
+          if (!entities.value.find(e => e.id === entity.id)) {
+            entities.value.push(entity)
+          }
+        },
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'scene_entities',
+          filter: `scene_id=eq.${sceneId}`,
+        },
+        (payload) => {
+          const updated = payload.new as SceneEntity
+          const idx = entities.value.findIndex(e => e.id === updated.id)
+          if (idx !== -1) entities.value[idx] = updated
+        },
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'scene_entities',
+          filter: `scene_id=eq.${sceneId}`,
+        },
+        (payload) => {
+          entities.value = entities.value.filter(e => e.id !== (payload.old as SceneEntity).id)
+        },
+      )
+      .subscribe()
+
+    return () => { supabase.removeChannel(channel) }
+  }
+
+  return {
+    scenes: readonly(scenes),
+    entities: readonly(entities),
+    loading: readonly(loading),
+    error: readonly(error),
+    fetchScenes,
+    createScene,
+    uploadBattlemap,
+    deleteScene,
+    fetchEntities,
+    addEntity,
+    updateEntity,
+    moveEntity,
+    removeEntity,
+    subscribeToEntities,
+  }
+}

--- a/app/docs/adr/001-player-access-pattern.md
+++ b/app/docs/adr/001-player-access-pattern.md
@@ -1,0 +1,59 @@
+# ADR-001 — Pattern d'accès joueur via server endpoints
+
+**Date :** 2026-03-29
+**Statut :** Accepté
+**Contexte :** Code review PR #4
+
+## Contexte
+
+L'application a deux types d'acteurs : le MJ (authentifié Supabase Auth) et le joueur (anonyme, identifié uniquement par un `join_code`). Supabase RLS est activé sur toutes les tables.
+
+La première implémentation du composable `usePlayerSession` lisait directement les tables `sessions`, `scenes` et `scene_entities` via le client Supabase anon, sans qu'il existe de policy RLS SELECT pour les joueurs sur ces tables. En production (RLS activé), ces requêtes retournaient silencieusement 0 résultats, rendant la fonctionnalité joueur entièrement non opérationnelle.
+
+## Décision
+
+**Toute lecture de données par un joueur anonyme transite par un server endpoint Nuxt.**
+
+Le client joueur n'appelle jamais directement `supabase.from(table).select(...)` pour les tables métier. À la place :
+
+1. Le front-end appelle un endpoint Nitro (`$fetch('/api/session/...')`)
+2. L'endpoint valide le `participant_id` et `session_id` (correspondance en base)
+3. L'endpoint utilise `useSupabaseAdmin()` (service_role) pour lire les données
+4. L'endpoint retourne uniquement les champs nécessaires à l'UI joueur
+
+Le schéma SQL ne définit **pas** de policies SELECT anon sur `sessions`, `scenes`, `scene_entities` — c'est intentionnel et documenté dans le fichier de migration.
+
+## Alternatives considérées
+
+### Option A : Ajouter des policies RLS SELECT anon
+
+```sql
+CREATE POLICY "sessions_player_read" ON sessions FOR SELECT TO anon
+  USING (status != 'ended');
+```
+
+**Rejeté** : sans notion d'identité joueur côté Supabase, toute policy anon est équivalente à un accès public sur ces tables. N'importe qui connaissant la clé anon publique pourrait lire toutes les sessions actives de tous les MJ.
+
+### Option B : Auth anonyme Supabase
+
+Activer l'auth anonyme de Supabase lors du `join` pour créer une identité éphémère, puis écrire des policies RLS basées sur `auth.uid()`.
+
+**Non retenu pour l'instant** : augmente la complexité (gestion des sessions auth éphémères, synchronisation avec `session_participants`) sans bénéfice fonctionnel immédiat dans le contexte actuel.
+
+### Option C : Server endpoints (retenu)
+
+**Avantages :**
+- Sécurité centralisée : la validation du `participant_id` est un seul point d'entrée, facile à auditer
+- Contrôle total des données exposées (sélections explicites, filtrage `visible_to_players`)
+- Cohérent avec l'endpoint `join.post.ts` déjà existant
+
+**Inconvénients :**
+- Tout changement de structure de données nécessite une mise à jour de l'endpoint
+- Pas de bénéfice direct des subscriptions Realtime Supabase (les mises à jour temps réel restent via le canal Realtime anon, qui fonctionne différemment du SELECT RLS)
+
+## Conséquences
+
+- `usePlayerSession.restore()` appelle `$fetch('/api/session/${id}/state?participant_id=${pid}')` au lieu de lire Supabase directement
+- Endpoint créé : `server/api/session/[id]/state.get.ts`
+- Les subscriptions Realtime du joueur restent via le client Supabase anon (les canaux Realtime ont un modèle d'autorisation différent du RLS SELECT standard)
+- Toute future donnée nécessaire au joueur doit être ajoutée à cet endpoint (ou un endpoint dédié) — jamais en ajoutant une policy anon directe

--- a/app/docs/architecture.md
+++ b/app/docs/architecture.md
@@ -1,0 +1,104 @@
+# Architecture — Compagnon JdR
+
+## Vue d'ensemble
+
+Application web de support pour les parties de jeu de rôle, construite avec Nuxt 3 et Supabase. Elle sert deux types d'utilisateurs avec des parcours distincts.
+
+## Modèle d'identité
+
+| Acteur | Identité | Credential |
+|---|---|---|
+| MJ (Game Master) | Supabase Auth (`auth.uid()`) | Email + mot de passe |
+| Joueur | Anonyme | `join_code` de session (6 chars) + `participant_id` (UUID, localStorage) |
+
+Cette asymétrie est le principe central qui gouverne toutes les décisions d'accès aux données.
+
+## Stack technique
+
+- **Nuxt 3** — framework full-stack (SSR + server endpoints via Nitro)
+- **@nuxtjs/supabase** — intégration Supabase Auth pour le MJ, client anon pour les joueurs
+- **@nuxt/ui** — composants UI
+- **Supabase** — Postgres (données), RLS (sécurité), Realtime (temps réel), Storage (battlemaps)
+- **TypeScript strict**
+
+## Parcours MJ
+
+```
+Login (Supabase Auth)
+  └─ Dashboard campagnes (/gm)
+      └─ Détail campagne (/gm/campaigns/[id])
+          ├─ Gestion personnages (/gm/campaigns/[id]/characters/[charId])
+          └─ Session live (/gm/campaigns/[id]/session/[sessionId])
+              ├─ Gestion scènes + entités
+              ├─ Vue participants temps réel
+              └─ Upload battlemaps (Supabase Storage)
+```
+
+Le middleware `gm.ts` protège toutes les routes `/gm/**` en vérifiant la session Supabase Auth.
+
+## Parcours Joueur
+
+```
+Page d'accueil (/)
+  └─ Rejoindre (/player/join)
+      └─ [Saisit le join_code à 6 chars]
+          └─ Scène en temps réel (/player/scene)
+              └─ Feuille de personnage (/player/sheet)
+```
+
+Le middleware `player-session.ts` vérifie la présence de l'état local (`session_id + participant_id` dans localStorage). Le joueur n'a aucun compte Supabase.
+
+## Accès aux données
+
+### MJ (authentifié)
+
+Le MJ utilise le client Supabase front-end (`useSupabaseClient()`). Le RLS autorise toutes les opérations sur les ressources dont `gm_user_id = auth.uid()`.
+
+### Joueur (anonyme)
+
+> Voir aussi : [ADR-001 — Pattern d'accès joueur](./adr/001-player-access-pattern.md)
+
+Le joueur ne lit **jamais** directement les tables Supabase depuis le front-end. Toutes ses lectures transitent par des server endpoints Nuxt qui :
+1. Valident le `participant_id` (correspondance `session_participants.id + session_id`)
+2. Utilisent `useSupabaseAdmin()` (clé `service_role`) pour contourner le RLS
+3. Retournent uniquement les champs nécessaires à l'UI joueur
+
+```
+Client joueur (anon)
+  └─ $fetch('/api/session/[id]/state?participant_id=xxx')
+      └─ Server endpoint (Nitro)
+          ├─ Valide participant_id ↔ session_id
+          ├─ useSupabaseAdmin() ← service_role, contourne RLS
+          └─ Retourne { session, active_scene, scene_entities (visible uniquement) }
+```
+
+## Realtime
+
+Supabase Realtime est activé sur trois tables : `sessions`, `scenes`, `scene_entities`.
+
+### Côté MJ (`useGMSession`, `useScene`)
+- Souscription directe via le client Supabase (authentifié, RLS autorise)
+- Sur INSERT de `session_participants` : **refetch le participant complet** avec `character:characters(*)` (le payload Realtime ne contient pas les relations jointes)
+
+### Côté joueur (`usePlayerSession`)
+- Souscription directe via le client Supabase anon — **exception justifiée** : les subscriptions Realtime ne passent pas par RLS SELECT de la même façon. Le canal est établi après validation côté serveur.
+- Sur changement de `active_scene_id` : nettoyage de l'ancienne subscription avant création de la nouvelle (éviter les memory leaks)
+
+## Schéma de base de données
+
+Tables principales :
+
+| Table | Description | RLS |
+|---|---|---|
+| `campaigns` | Campagnes du MJ | MJ owner uniquement |
+| `characters` | Personnages (feuille JSONB) | MJ CRUD, lecture joueur via server endpoint |
+| `sessions` | Sessions de jeu | MJ CRUD, lecture joueur via server endpoint |
+| `session_participants` | Joueurs d'une session | Contrôlé côté serveur |
+| `scenes` | Scènes d'une session | MJ CRUD, lecture joueur via server endpoint |
+| `scene_entities` | Entités d'une scène | MJ CRUD, lecture joueur filtrée `visible_to_players` |
+
+Le schéma complet avec indexes, triggers `updated_at` et configuration Realtime est dans `supabase/migrations/001_initial_schema.sql`.
+
+## Génération des join_codes
+
+Les codes de session sont générés côté serveur (`server/utils/generateJoinCode.ts`) avec `crypto.randomInt` (Node.js), pas `Math.random()`. L'espace est `32^6 ≈ 1 milliard` de combinaisons avec un alphabet sans ambiguïté (pas de `0/O`, `1/I`).

--- a/app/docs/security.md
+++ b/app/docs/security.md
@@ -1,0 +1,86 @@
+# Sécurité — Modèle RLS et patterns d'accès
+
+## Principes généraux
+
+1. **Le RLS Supabase est activé sur toutes les tables** — pas d'accès sans policy explicite
+2. **Le joueur anonyme n'a aucune policy SELECT directe** — toutes ses lectures passent par des server endpoints
+3. **Aucun `select('*')` dans les endpoints publics** — sélections explicites uniquement
+4. **Inputs normalisés côté serveur** — `.trim().toUpperCase()` sur les join_codes, ne pas faire confiance au format client
+
+## Policies RLS par table
+
+### `campaigns`
+- `campaigns_gm_all` : MJ CRUD complet (`auth.uid() = gm_user_id`)
+- Colonne `gm_user_id` doit être fournie à l'INSERT (ou via `DEFAULT auth.uid()` si ajouté au schéma)
+
+### `characters`
+- `characters_gm_all` : MJ CRUD complet (`auth.uid() = gm_user_id` via la campagne)
+- Pas de policy SELECT anon — les feuilles de personnage ne sont jamais accessibles directement par les joueurs
+
+### `sessions`
+- `sessions_gm_all` : MJ CRUD complet
+- Pas de policy SELECT anon — **choix délibéré** : la lecture par le joueur passe par le server endpoint `/api/session/[id]/state`
+
+### `scenes`
+- `scenes_gm_all` : MJ CRUD complet
+- Pas de policy SELECT anon — même principe que `sessions`
+
+### `scene_entities`
+- `scene_entities_gm_all` : MJ CRUD complet
+- Pas de policy SELECT anon — le server endpoint filtre `visible_to_players = true` avant de retourner les entités
+
+### `session_participants`
+- Géré entièrement côté serveur (endpoints avec client admin)
+
+## Server endpoints et validation joueur
+
+Tout endpoint servant des données à un joueur doit :
+
+```typescript
+// 1. Extraire les identifiants
+const sessionId = getRouterParam(event, 'id')
+const participantId = getQuery(event).participant_id as string
+
+// 2. Valider la correspondance participant ↔ session
+const { data: participant } = await admin
+  .from('session_participants')
+  .select('id')
+  .eq('id', participantId)
+  .eq('session_id', sessionId)
+  .single()
+
+if (!participant) throw createError({ statusCode: 403, ... })
+
+// 3. Lire avec le client admin (service_role)
+const { data } = await admin.from('sessions').select('id, status, active_scene_id, ...').single()
+```
+
+## Ce qu'on ne doit jamais exposer aux joueurs
+
+| Donnée | Raison |
+|---|---|
+| `gm_user_id` | UUID interne de l'identité Supabase du MJ |
+| `created_at`, `updated_at` | Métadonnées opérationnelles sans utilité UI |
+| `scene_entities` avec `visible_to_players = false` | Entités cachées (secret MJ) |
+| `characters.data` d'un autre joueur | Feuille de perso privée |
+
+## Génération de codes
+
+Utiliser exclusivement `crypto.randomInt` de `node:crypto` pour tout code ou token généré côté serveur :
+
+```typescript
+import { randomInt } from 'node:crypto'
+
+const CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+export function generateJoinCode(length = 6): string {
+  return Array.from({ length }, () => CHARS[randomInt(0, CHARS.length)]).join('')
+}
+```
+
+`Math.random()` est interdit pour les valeurs servant de credential ou d'identifiant secret.
+
+## Points d'attention futurs
+
+- **Rate-limiting sur `/api/session/join`** : l'espace de `join_code` est ~1 milliard, mais sans rate-limiting un brute-force distribué reste possible. Ajouter un middleware Nitro de rate-limiting par IP.
+- **TTL des sessions** : prévoir l'expiration automatique des sessions `active` via un trigger ou un job cron Supabase.
+- **Auth anonyme Supabase** : si la complexité des policies RLS joueur augmente, envisager l'activation de l'auth anonyme Supabase pour lier une identité côté DB sans imposer d'inscription.

--- a/app/docs/security.md
+++ b/app/docs/security.md
@@ -15,7 +15,8 @@
 
 ### `characters`
 - `characters_gm_all` : MJ CRUD complet (`auth.uid() = gm_user_id` via la campagne)
-- Pas de policy SELECT anon — les feuilles de personnage ne sont jamais accessibles directement par les joueurs
+- `characters_player_read` : lecture anonyme restreinte — permet à un joueur de lire uniquement le personnage qui lui est assigné via `session_participants` (`sp.character_id = characters.id`), dans une session dont le statut est `active`. Cette policy ne donne pas accès à l'ensemble des personnages de la campagne.
+- Malgré l'existence de `characters_player_read`, les composables joueur passent toujours par le server endpoint `/api/session/[id]/characters` (client admin) afin de contrôler précisément les champs exposés : uniquement `id`, `name`, `player_name` — jamais `data` (feuille de perso complète) ni les timestamps internes.
 
 ### `sessions`
 - `sessions_gm_all` : MJ CRUD complet

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="min-h-screen bg-gray-950 text-gray-100">
+    <slot />
+  </div>
+</template>

--- a/app/layouts/fullscreen.vue
+++ b/app/layouts/fullscreen.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="min-h-screen bg-gray-950 text-gray-100 overflow-auto">
+    <slot />
+  </div>
+</template>

--- a/app/layouts/minimal.vue
+++ b/app/layouts/minimal.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="min-h-screen bg-gray-950 text-gray-100">
+    <slot />
+  </div>
+</template>

--- a/app/middleware/gm.ts
+++ b/app/middleware/gm.ts
@@ -1,0 +1,11 @@
+/**
+ * Middleware de protection des routes /gm/*.
+ * Redirige vers la page de connexion si le MJ n'est pas authentifié.
+ */
+export default defineNuxtRouteMiddleware(() => {
+  const user = useSupabaseUser()
+
+  if (!user.value) {
+    return navigateTo('/login')
+  }
+})

--- a/app/middleware/player-session.ts
+++ b/app/middleware/player-session.ts
@@ -1,0 +1,17 @@
+/**
+ * Middleware pour les routes /player/*.
+ * Vérifie que la session joueur est présente dans le localStorage.
+ * Si absente, redirige vers /player/join.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  // Côté serveur, impossible de lire le localStorage → on laisse passer
+  // La page côté client prendra le relais avec restore()
+  if (import.meta.server) return
+
+  const STORAGE_KEY = 'compagnon_player_session'
+  const stored = localStorage.getItem(STORAGE_KEY)
+
+  if (!stored && to.path !== '/player/join') {
+    return navigateTo('/player/join')
+  }
+})

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -1,0 +1,31 @@
+export default defineNuxtConfig({
+  compatibilityDate: '2024-11-01',
+
+  modules: [
+    '@nuxt/ui',
+    '@nuxtjs/supabase',
+  ],
+
+  supabase: {
+    // Seul le MJ a un compte Supabase Auth.
+    // Les joueurs accèdent via un code de session (pas de redirect auth).
+    redirect: false,
+  },
+
+  runtimeConfig: {
+    // Clés serveur uniquement (non exposées au client)
+    supabaseServiceKey: process.env.SUPABASE_SERVICE_KEY,
+    sessionSecret: process.env.SESSION_SECRET,
+    public: {
+      // Clés publiques accessibles côté client
+      supabaseUrl: process.env.SUPABASE_URL,
+      supabaseKey: process.env.SUPABASE_KEY,
+    },
+  },
+
+  typescript: {
+    strict: true,
+  },
+
+  devtools: { enabled: true },
+})

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "compagnon-jdr",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "preview": "nuxt preview",
+    "postinstall": "nuxt prepare",
+    "lint": "eslint .",
+    "typecheck": "nuxt typecheck"
+  },
+  "dependencies": {
+    "@nuxt/ui": "^3.0.0",
+    "@nuxtjs/supabase": "^1.4.0",
+    "nuxt": "^3.15.0",
+    "vue": "^3.5.0",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@nuxt/eslint": "^0.7.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/app/pages/gm/campaigns/[id]/characters/[charId].vue
+++ b/app/pages/gm/campaigns/[id]/characters/[charId].vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import type { TORCharacterData, TORSkill, TORWeapon } from '~/types/rpg'
+
+definePageMeta({ middleware: 'gm' })
+
+const route = useRoute()
+const campaignId = route.params.id as string
+const charId = route.params.charId as string
+
+const { characters, fetchAll, updateData } = useCharacter(campaignId)
+const saving = ref(false)
+const saved = ref(false)
+
+const character = computed(() => characters.value.find(c => c.id === charId))
+const data = ref<TORCharacterData | null>(null)
+
+onMounted(async () => {
+  await fetchAll()
+  if (character.value) {
+    data.value = structuredClone(character.value.data)
+  }
+})
+
+async function save() {
+  if (!data.value) return
+  saving.value = true
+  await updateData(charId, data.value)
+  saving.value = false
+  saved.value = true
+  setTimeout(() => { saved.value = false }, 2000)
+}
+
+function addSkill(group: 'skills_strength' | 'skills_heart' | 'skills_mind') {
+  if (!data.value) return
+  data.value[group].push({ name: '', rank: 0, favoured: false })
+}
+
+function removeSkill(group: 'skills_strength' | 'skills_heart' | 'skills_mind', idx: number) {
+  if (!data.value) return
+  data.value[group].splice(idx, 1)
+}
+
+function addWeapon() {
+  if (!data.value) return
+  data.value.weapons.push({ name: '', damage: 5, injury: 16, load: 2 })
+}
+
+function removeWeapon(idx: number) {
+  if (!data.value) return
+  data.value.weapons.splice(idx, 1)
+}
+</script>
+
+<template>
+  <div class="min-h-screen p-6 max-w-3xl mx-auto">
+    <div class="flex items-center gap-2 text-sm text-gray-400 mb-6">
+      <NuxtLink to="/gm" class="hover:text-white">Campagnes</NuxtLink>
+      <UIcon name="i-heroicons-chevron-right" />
+      <NuxtLink :to="`/gm/campaigns/${campaignId}`" class="hover:text-white">Campagne</NuxtLink>
+      <UIcon name="i-heroicons-chevron-right" />
+      <span class="text-white">{{ character?.name }}</span>
+    </div>
+
+    <div v-if="!data" class="flex justify-center py-12">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
+    </div>
+
+    <template v-else>
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold">{{ character?.name }}</h1>
+        <UButton :loading="saving" :color="saved ? 'green' : 'primary'" @click="save">
+          {{ saved ? 'Sauvegardé !' : 'Sauvegarder' }}
+        </UButton>
+      </div>
+
+      <div class="space-y-8">
+        <!-- Identité -->
+        <section>
+          <h2 class="section-title">Identité</h2>
+          <div class="grid grid-cols-2 gap-4">
+            <UFormGroup label="Culture">
+              <UInput v-model="data.culture" />
+            </UFormGroup>
+            <UFormGroup label="Vocation">
+              <UInput v-model="data.vocation" />
+            </UFormGroup>
+            <UFormGroup label="Niveau de vie">
+              <UInput v-model="data.standard_of_living" />
+            </UFormGroup>
+          </div>
+        </section>
+
+        <!-- Attributs -->
+        <section>
+          <h2 class="section-title">Attributs principaux</h2>
+          <div class="grid grid-cols-3 gap-4">
+            <UFormGroup label="Force">
+              <UInput v-model.number="data.attributes.strength" type="number" min="1" max="7" />
+            </UFormGroup>
+            <UFormGroup label="Cœur">
+              <UInput v-model.number="data.attributes.heart" type="number" min="1" max="7" />
+            </UFormGroup>
+            <UFormGroup label="Esprit">
+              <UInput v-model.number="data.attributes.mind" type="number" min="1" max="7" />
+            </UFormGroup>
+          </div>
+        </section>
+
+        <!-- Secondaires -->
+        <section>
+          <h2 class="section-title">Attributs secondaires</h2>
+          <div class="grid grid-cols-3 gap-4">
+            <UFormGroup label="Endurance max">
+              <UInput v-model.number="data.endurance_max" type="number" min="1" />
+            </UFormGroup>
+            <UFormGroup label="Endurance actuelle">
+              <UInput v-model.number="data.endurance_current" type="number" min="0" :max="data.endurance_max" />
+            </UFormGroup>
+            <UFormGroup label="Espoir max">
+              <UInput v-model.number="data.hope_max" type="number" min="1" />
+            </UFormGroup>
+            <UFormGroup label="Espoir actuel">
+              <UInput v-model.number="data.hope_current" type="number" min="0" :max="data.hope_max" />
+            </UFormGroup>
+            <UFormGroup label="Ombre">
+              <UInput v-model.number="data.shadow" type="number" min="0" />
+            </UFormGroup>
+            <UFormGroup label="Parade">
+              <UInput v-model.number="data.parry" type="number" min="0" />
+            </UFormGroup>
+          </div>
+        </section>
+
+        <!-- Compétences -->
+        <section
+          v-for="[label, group] in ([
+            ['Compétences Force', 'skills_strength'],
+            ['Compétences Cœur', 'skills_heart'],
+            ['Compétences Esprit', 'skills_mind'],
+          ] as [string, keyof TORCharacterData][])"
+          :key="group"
+        >
+          <div class="flex items-center justify-between mb-2">
+            <h2 class="section-title">{{ label }}</h2>
+            <UButton size="xs" icon="i-heroicons-plus" @click="addSkill(group as 'skills_strength' | 'skills_heart' | 'skills_mind')" />
+          </div>
+          <div class="space-y-2">
+            <div
+              v-for="(skill, idx) in (data[group] as TORSkill[])"
+              :key="idx"
+              class="flex items-center gap-2"
+            >
+              <UInput v-model="skill.name" placeholder="Nom" class="flex-1" />
+              <UInput v-model.number="skill.rank" type="number" min="0" max="6" class="w-16" />
+              <UToggle v-model="skill.favoured" />
+              <span class="text-xs text-gray-500">Fav.</span>
+              <UButton size="xs" color="red" variant="ghost" icon="i-heroicons-trash" @click="removeSkill(group as 'skills_strength' | 'skills_heart' | 'skills_mind', idx)" />
+            </div>
+          </div>
+        </section>
+
+        <!-- Armes -->
+        <section>
+          <div class="flex items-center justify-between mb-2">
+            <h2 class="section-title">Armement</h2>
+            <UButton size="xs" icon="i-heroicons-plus" @click="addWeapon" />
+          </div>
+          <div class="space-y-2">
+            <div
+              v-for="(w, idx) in (data.weapons as TORWeapon[])"
+              :key="idx"
+              class="grid grid-cols-5 gap-2 items-center"
+            >
+              <UInput v-model="w.name" placeholder="Nom" class="col-span-2" />
+              <UInput v-model.number="w.damage" type="number" placeholder="Dégâts" />
+              <UInput v-model.number="w.injury" type="number" placeholder="Blessure" />
+              <UButton size="xs" color="red" variant="ghost" icon="i-heroicons-trash" @click="removeWeapon(idx)" />
+            </div>
+          </div>
+        </section>
+
+        <!-- XP -->
+        <section>
+          <h2 class="section-title">Progression</h2>
+          <div class="grid grid-cols-2 gap-4">
+            <UFormGroup label="Expérience">
+              <UInput v-model.number="data.experience" type="number" min="0" />
+            </UFormGroup>
+            <UFormGroup label="Avancement">
+              <UInput v-model.number="data.advancement" type="number" min="0" />
+            </UFormGroup>
+          </div>
+        </section>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.section-title {
+  @apply text-sm uppercase text-gray-500 font-semibold mb-3;
+}
+</style>

--- a/app/pages/gm/campaigns/[id]/index.vue
+++ b/app/pages/gm/campaigns/[id]/index.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import type { Campaign, GameSession } from '~/types/rpg'
+
+definePageMeta({ middleware: 'gm' })
+
+const route = useRoute()
+const supabase = useSupabaseClient()
+const campaignId = route.params.id as string
+
+const campaign = ref<Campaign | null>(null)
+const sessions = ref<GameSession[]>([])
+const loading = ref(true)
+const starting = ref(false)
+
+const { characters, fetchAll: fetchCharacters, create: createCharacter, remove: removeCharacter } = useCharacter(campaignId)
+
+const showNewCharacter = ref(false)
+const newCharName = ref('')
+const newPlayerName = ref('')
+
+async function fetchData() {
+  const [{ data: campaignData }, { data: sessionsData }] = await Promise.all([
+    supabase.from('campaigns').select('*').eq('id', campaignId).single(),
+    supabase.from('sessions').select('*').eq('campaign_id', campaignId).order('created_at', { ascending: false }),
+  ])
+  campaign.value = campaignData as Campaign
+  sessions.value = (sessionsData as GameSession[]) ?? []
+  await fetchCharacters()
+  loading.value = false
+}
+
+const { createSession } = useGMSession()
+
+async function startSession() {
+  starting.value = true
+  const session = await createSession(campaignId)
+  if (session) {
+    await navigateTo(`/gm/campaigns/${campaignId}/session/${session.id}`)
+  }
+  starting.value = false
+}
+
+async function handleCreateCharacter() {
+  await createCharacter(newCharName.value, newPlayerName.value)
+  newCharName.value = ''
+  newPlayerName.value = ''
+  showNewCharacter.value = false
+}
+
+const activeSession = computed(() =>
+  sessions.value.find(s => s.status === 'waiting' || s.status === 'active'),
+)
+
+onMounted(fetchData)
+</script>
+
+<template>
+  <div class="min-h-screen p-6 max-w-5xl mx-auto">
+    <div v-if="loading" class="flex justify-center py-12">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
+    </div>
+
+    <template v-else>
+      <!-- Breadcrumb + header -->
+      <div class="flex items-center gap-2 text-sm text-gray-400 mb-6">
+        <NuxtLink to="/gm" class="hover:text-white">Campagnes</NuxtLink>
+        <UIcon name="i-heroicons-chevron-right" />
+        <span class="text-white">{{ campaign?.name }}</span>
+      </div>
+
+      <div class="flex items-start justify-between mb-8">
+        <div>
+          <h1 class="text-2xl font-bold">{{ campaign?.name }}</h1>
+          <p v-if="campaign?.description" class="text-gray-400 mt-1">{{ campaign.description }}</p>
+        </div>
+
+        <UButton
+          v-if="activeSession"
+          color="primary"
+          icon="i-heroicons-play"
+          :to="`/gm/campaigns/${campaignId}/session/${activeSession.id}`"
+        >
+          Reprendre la session
+        </UButton>
+        <UButton
+          v-else
+          color="primary"
+          icon="i-heroicons-play"
+          :loading="starting"
+          @click="startSession"
+        >
+          Lancer une session
+        </UButton>
+      </div>
+
+      <div class="grid gap-8 lg:grid-cols-2">
+        <!-- Personnages -->
+        <section>
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-semibold">Personnages</h2>
+            <UButton size="sm" icon="i-heroicons-plus" @click="showNewCharacter = true">
+              Ajouter
+            </UButton>
+          </div>
+
+          <UModal v-model="showNewCharacter" title="Nouveau personnage">
+            <template #body>
+              <div class="space-y-4">
+                <UFormGroup label="Nom du personnage" required>
+                  <UInput v-model="newCharName" placeholder="Gandalf le Gris" />
+                </UFormGroup>
+                <UFormGroup label="Nom du joueur">
+                  <UInput v-model="newPlayerName" placeholder="Tolkien" />
+                </UFormGroup>
+              </div>
+            </template>
+            <template #footer>
+              <div class="flex justify-end gap-2">
+                <UButton variant="ghost" @click="showNewCharacter = false">Annuler</UButton>
+                <UButton @click="handleCreateCharacter">Créer</UButton>
+              </div>
+            </template>
+          </UModal>
+
+          <div v-if="characters.length === 0" class="text-gray-500 text-sm py-4">
+            Aucun personnage dans cette campagne.
+          </div>
+
+          <div class="space-y-2">
+            <UCard
+              v-for="char in characters"
+              :key="char.id"
+              class="flex items-center justify-between"
+            >
+              <div>
+                <p class="font-medium">{{ char.name }}</p>
+                <p v-if="char.player_name" class="text-sm text-gray-400">{{ char.player_name }}</p>
+              </div>
+              <div class="flex gap-2">
+                <UButton
+                  size="xs"
+                  variant="ghost"
+                  icon="i-heroicons-pencil"
+                  :to="`/gm/campaigns/${campaignId}/characters/${char.id}`"
+                />
+                <UButton
+                  size="xs"
+                  color="red"
+                  variant="ghost"
+                  icon="i-heroicons-trash"
+                  @click="removeCharacter(char.id)"
+                />
+              </div>
+            </UCard>
+          </div>
+        </section>
+
+        <!-- Historique des sessions -->
+        <section>
+          <h2 class="text-lg font-semibold mb-4">Sessions passées</h2>
+          <div v-if="sessions.filter(s => s.status === 'ended').length === 0" class="text-gray-500 text-sm py-4">
+            Aucune session terminée.
+          </div>
+          <div class="space-y-2">
+            <UCard
+              v-for="s in sessions.filter(s => s.status === 'ended')"
+              :key="s.id"
+            >
+              <div class="flex justify-between items-center">
+                <p class="text-sm text-gray-400">
+                  {{ new Date(s.created_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' }) }}
+                </p>
+                <UBadge color="neutral">Terminée</UBadge>
+              </div>
+            </UCard>
+          </div>
+        </section>
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/pages/gm/campaigns/[id]/session/[sessionId].vue
+++ b/app/pages/gm/campaigns/[id]/session/[sessionId].vue
@@ -1,0 +1,362 @@
+<script setup lang="ts">
+import type { EntityType, EntityData, EnemyData } from '~/types/rpg'
+
+definePageMeta({ middleware: 'gm' })
+
+const route = useRoute()
+const sessionId = route.params.sessionId as string
+const campaignId = route.params.id as string
+
+const {
+  session,
+  participants,
+  loading: sessionLoading,
+  loadSession,
+  setActiveScene,
+  endSession,
+  subscribeToSession,
+} = useGMSession()
+
+const {
+  scenes,
+  entities,
+  fetchScenes,
+  createScene,
+  fetchEntities,
+  addEntity,
+  updateEntity,
+  removeEntity,
+  uploadBattlemap,
+  subscribeToEntities,
+} = useScene(sessionId)
+
+const showNewScene = ref(false)
+const newSceneName = ref('')
+const showEndConfirm = ref(false)
+const activeSceneId = ref<string | null>(null)
+const showAddEntity = ref(false)
+const entityType = ref<EntityType>('enemy')
+const entityName = ref('')
+const entityEndurance = ref(10)
+const entityVisible = ref(true)
+const battlemapInput = ref<HTMLInputElement | null>(null)
+const uploadingMap = ref(false)
+
+let unsubSession: (() => void) | null = null
+let unsubEntities: (() => void) | null = null
+
+onMounted(async () => {
+  await loadSession(sessionId)
+  await fetchScenes()
+
+  if (session.value?.active_scene_id) {
+    activeSceneId.value = session.value.active_scene_id
+    await fetchEntities(session.value.active_scene_id)
+    unsubEntities = subscribeToEntities(session.value.active_scene_id)
+  }
+
+  unsubSession = subscribeToSession(sessionId)
+})
+
+onUnmounted(() => {
+  unsubSession?.()
+  unsubEntities?.()
+})
+
+const activeScene = computed(() =>
+  scenes.value.find(s => s.id === activeSceneId.value) ?? null,
+)
+
+async function handleSetScene(sceneId: string | null) {
+  unsubEntities?.()
+  await setActiveScene(sceneId)
+  activeSceneId.value = sceneId
+
+  if (sceneId) {
+    await fetchEntities(sceneId)
+    unsubEntities = subscribeToEntities(sceneId)
+  }
+}
+
+async function handleCreateScene() {
+  const scene = await createScene(newSceneName.value)
+  if (scene) {
+    newSceneName.value = ''
+    showNewScene.value = false
+    await handleSetScene(scene.id)
+  }
+}
+
+async function handleUploadBattlemap(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file || !activeSceneId.value) return
+  uploadingMap.value = true
+  await uploadBattlemap(activeSceneId.value, file)
+  uploadingMap.value = false
+}
+
+async function handleAddEntity() {
+  if (!activeSceneId.value || !entityName.value.trim()) return
+
+  const data: EntityData = entityType.value === 'enemy'
+    ? { endurance: entityEndurance.value, endurance_max: entityEndurance.value, parry: 14, armor: 0 } as EnemyData
+    : { description: '' }
+
+  await addEntity(activeSceneId.value, entityType.value, entityName.value.trim(), data, { x: 0, y: 0 }, entityVisible.value)
+  entityName.value = ''
+  entityEndurance.value = 10
+  showAddEntity.value = false
+}
+
+async function handleEndSession() {
+  await endSession()
+  showEndConfirm.value = false
+  navigateTo(`/gm/campaigns/${campaignId}`)
+}
+
+const visibleEntities = computed(() => entities.value.filter(e => e.visible_to_players))
+const hiddenEntities = computed(() => entities.value.filter(e => !e.visible_to_players))
+</script>
+
+<template>
+  <div class="min-h-screen p-4 flex flex-col gap-4">
+    <!-- Header session -->
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <NuxtLink :to="`/gm/campaigns/${campaignId}`" class="text-gray-400 hover:text-white">
+          <UIcon name="i-heroicons-arrow-left" />
+        </NuxtLink>
+        <div>
+          <h1 class="font-bold text-lg">Session en cours</h1>
+          <div class="flex items-center gap-2 text-sm">
+            <span class="text-gray-400">Code joueurs :</span>
+            <UBadge color="primary" variant="solid" class="font-mono text-base tracking-widest">
+              {{ session?.join_code }}
+            </UBadge>
+            <span class="text-gray-500">— partagez ce code avec vos joueurs</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex gap-2">
+        <UBadge
+          :color="session?.status === 'active' ? 'green' : 'yellow'"
+          class="capitalize"
+        >
+          {{ session?.status === 'active' ? 'En cours' : 'En attente' }}
+        </UBadge>
+        <UButton color="red" variant="soft" size="sm" @click="showEndConfirm = true">
+          Terminer
+        </UButton>
+      </div>
+    </div>
+
+    <div class="grid gap-4 lg:grid-cols-3 flex-1">
+      <!-- Colonne gauche : scènes + participants -->
+      <div class="space-y-4">
+        <!-- Scènes -->
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between">
+              <h2 class="font-semibold">Scènes</h2>
+              <UButton size="xs" icon="i-heroicons-plus" @click="showNewScene = true" />
+            </div>
+          </template>
+
+          <div class="space-y-1">
+            <button
+              v-for="scene in scenes"
+              :key="scene.id"
+              class="w-full text-left px-3 py-2 rounded-lg text-sm transition"
+              :class="activeSceneId === scene.id
+                ? 'bg-primary-600 text-white'
+                : 'hover:bg-gray-800 text-gray-300'"
+              @click="handleSetScene(scene.id)"
+            >
+              <div class="flex items-center justify-between">
+                <span class="truncate">{{ scene.name }}</span>
+                <UIcon
+                  v-if="activeSceneId === scene.id"
+                  name="i-heroicons-eye"
+                  class="shrink-0 ml-1"
+                />
+              </div>
+            </button>
+
+            <p v-if="scenes.length === 0" class="text-gray-500 text-sm py-2">
+              Aucune scène. Créez-en une pour commencer.
+            </p>
+          </div>
+        </UCard>
+
+        <!-- Participants -->
+        <UCard>
+          <template #header>
+            <h2 class="font-semibold">
+              Joueurs connectés
+              <UBadge class="ml-2" color="neutral" variant="soft">{{ participants.length }}</UBadge>
+            </h2>
+          </template>
+          <div v-if="participants.length === 0" class="text-gray-500 text-sm py-2">
+            En attente de joueurs...
+          </div>
+          <div class="space-y-2">
+            <div
+              v-for="p in participants"
+              :key="p.id"
+              class="flex items-center gap-2 text-sm"
+            >
+              <UIcon name="i-heroicons-user-circle" class="text-gray-400" />
+              <span>{{ p.player_name }}</span>
+              <span v-if="p.character" class="text-gray-500">— {{ p.character.name }}</span>
+            </div>
+          </div>
+        </UCard>
+      </div>
+
+      <!-- Colonne centrale : battlemap -->
+      <div class="lg:col-span-2">
+        <UCard class="h-full flex flex-col">
+          <template #header>
+            <div class="flex items-center justify-between">
+              <h2 class="font-semibold">
+                {{ activeScene?.name ?? 'Aucune scène active' }}
+              </h2>
+              <div v-if="activeScene" class="flex gap-2">
+                <UButton
+                  size="xs"
+                  variant="soft"
+                  icon="i-heroicons-photo"
+                  :loading="uploadingMap"
+                  @click="battlemapInput?.click()"
+                >
+                  Battlemap
+                </UButton>
+                <input
+                  ref="battlemapInput"
+                  type="file"
+                  accept="image/*"
+                  class="hidden"
+                  @change="handleUploadBattlemap"
+                >
+                <UButton
+                  size="xs"
+                  icon="i-heroicons-plus"
+                  @click="showAddEntity = true"
+                >
+                  Ajouter entité
+                </UButton>
+              </div>
+            </div>
+          </template>
+
+          <div class="flex-1 relative min-h-64 bg-gray-900 rounded-lg overflow-hidden">
+            <!-- Battlemap image -->
+            <img
+              v-if="activeScene?.battlemap_url"
+              :src="activeScene.battlemap_url"
+              class="w-full h-full object-contain"
+              alt="Battlemap"
+            >
+            <div v-else-if="activeScene" class="absolute inset-0 flex items-center justify-center text-gray-600">
+              <div class="text-center">
+                <UIcon name="i-heroicons-map" class="text-4xl mb-2" />
+                <p class="text-sm">Aucune battlemap. Importez une image.</p>
+              </div>
+            </div>
+            <div v-else class="absolute inset-0 flex items-center justify-center text-gray-600">
+              <p class="text-sm">Sélectionnez ou créez une scène à gauche.</p>
+            </div>
+
+            <!-- Tokens des entités visibles (positionnement simplifié) -->
+            <GMEntityToken
+              v-for="entity in entities"
+              :key="entity.id"
+              :entity="entity"
+              @update="updateEntity(entity.id, $event)"
+              @remove="removeEntity(entity.id)"
+            />
+          </div>
+
+          <!-- Liste des entités -->
+          <div v-if="activeScene && entities.length > 0" class="mt-3 space-y-1">
+            <p class="text-xs text-gray-500 uppercase tracking-wide">Entités</p>
+            <div class="flex flex-wrap gap-2">
+              <GMEntityBadge
+                v-for="entity in entities"
+                :key="entity.id"
+                :entity="entity"
+                @toggle-visibility="updateEntity(entity.id, { visible_to_players: !entity.visible_to_players })"
+                @remove="removeEntity(entity.id)"
+              />
+            </div>
+          </div>
+        </UCard>
+      </div>
+    </div>
+
+    <!-- Modal nouvelle scène -->
+    <UModal v-model="showNewScene" title="Nouvelle scène">
+      <template #body>
+        <UFormGroup label="Nom de la scène" required>
+          <UInput v-model="newSceneName" placeholder="La Taverne du Poney Fringant..." />
+        </UFormGroup>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-2">
+          <UButton variant="ghost" @click="showNewScene = false">Annuler</UButton>
+          <UButton @click="handleCreateScene">Créer</UButton>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Modal ajouter entité -->
+    <UModal v-model="showAddEntity" title="Ajouter une entité">
+      <template #body>
+        <div class="space-y-4">
+          <UFormGroup label="Type">
+            <USelect
+              v-model="entityType"
+              :options="[
+                { label: 'Ennemi', value: 'enemy' },
+                { label: 'PNJ', value: 'npc' },
+                { label: 'Objet', value: 'item' },
+                { label: 'Zone', value: 'zone' },
+              ]"
+            />
+          </UFormGroup>
+          <UFormGroup label="Nom" required>
+            <UInput v-model="entityName" placeholder="Gobelin, Épée de Lumière..." />
+          </UFormGroup>
+          <UFormGroup v-if="entityType === 'enemy'" label="Endurance">
+            <UInput v-model.number="entityEndurance" type="number" min="1" />
+          </UFormGroup>
+          <UFormGroup label="Visible par les joueurs">
+            <UToggle v-model="entityVisible" />
+          </UFormGroup>
+        </div>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-2">
+          <UButton variant="ghost" @click="showAddEntity = false">Annuler</UButton>
+          <UButton @click="handleAddEntity">Ajouter</UButton>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Modal confirmation fin de session -->
+    <UModal v-model="showEndConfirm" title="Terminer la session ?">
+      <template #body>
+        <p class="text-gray-300">
+          La session sera marquée comme terminée. Les joueurs ne pourront plus la rejoindre.
+        </p>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-2">
+          <UButton variant="ghost" @click="showEndConfirm = false">Annuler</UButton>
+          <UButton color="red" @click="handleEndSession">Terminer la session</UButton>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/app/pages/gm/index.vue
+++ b/app/pages/gm/index.vue
@@ -25,11 +25,21 @@ async function createCampaign() {
   if (!newCampaignName.value.trim()) return
   creating.value = true
 
-  const { data } = await supabase
+  const { data, error: insertError } = await supabase
     .from('campaigns')
-    .insert({ name: newCampaignName.value.trim(), description: newCampaignDesc.value.trim() || null })
+    .insert({
+      name: newCampaignName.value.trim(),
+      description: newCampaignDesc.value.trim() || null,
+      gm_user_id: user.value!.id,
+    })
     .select()
     .single()
+
+  if (insertError) {
+    console.error('Erreur création campagne:', insertError)
+    creating.value = false
+    return
+  }
 
   if (data) {
     campaigns.value.unshift(data as Campaign)

--- a/app/pages/gm/index.vue
+++ b/app/pages/gm/index.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import type { Campaign } from '~/types/rpg'
+
+definePageMeta({ middleware: 'gm' })
+
+const supabase = useSupabaseClient()
+const user = useSupabaseUser()
+const campaigns = ref<Campaign[]>([])
+const loading = ref(true)
+const showNewCampaign = ref(false)
+const newCampaignName = ref('')
+const newCampaignDesc = ref('')
+const creating = ref(false)
+
+async function fetchCampaigns() {
+  const { data } = await supabase
+    .from('campaigns')
+    .select('*')
+    .order('created_at', { ascending: false })
+  campaigns.value = (data as Campaign[]) ?? []
+  loading.value = false
+}
+
+async function createCampaign() {
+  if (!newCampaignName.value.trim()) return
+  creating.value = true
+
+  const { data } = await supabase
+    .from('campaigns')
+    .insert({ name: newCampaignName.value.trim(), description: newCampaignDesc.value.trim() || null })
+    .select()
+    .single()
+
+  if (data) {
+    campaigns.value.unshift(data as Campaign)
+    newCampaignName.value = ''
+    newCampaignDesc.value = ''
+    showNewCampaign.value = false
+  }
+  creating.value = false
+}
+
+async function logout() {
+  await supabase.auth.signOut()
+  navigateTo('/login')
+}
+
+onMounted(fetchCampaigns)
+</script>
+
+<template>
+  <div class="min-h-screen p-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-2xl font-bold">Mes Campagnes</h1>
+        <p class="text-gray-400 text-sm">{{ user?.email }}</p>
+      </div>
+      <div class="flex gap-2">
+        <UButton
+          color="primary"
+          icon="i-heroicons-plus"
+          @click="showNewCampaign = true"
+        >
+          Nouvelle campagne
+        </UButton>
+        <UButton variant="ghost" icon="i-heroicons-arrow-right-on-rectangle" @click="logout">
+          Déconnexion
+        </UButton>
+      </div>
+    </div>
+
+    <!-- Modal nouvelle campagne -->
+    <UModal v-model="showNewCampaign" title="Nouvelle campagne">
+      <template #body>
+        <div class="space-y-4">
+          <UFormGroup label="Nom de la campagne" required>
+            <UInput v-model="newCampaignName" placeholder="La Quête de l'Anneau Unique..." />
+          </UFormGroup>
+          <UFormGroup label="Description">
+            <UTextarea v-model="newCampaignDesc" placeholder="Notes sur la campagne..." rows="3" />
+          </UFormGroup>
+        </div>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-2">
+          <UButton variant="ghost" @click="showNewCampaign = false">Annuler</UButton>
+          <UButton :loading="creating" @click="createCampaign">Créer</UButton>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Liste des campagnes -->
+    <div v-if="loading" class="flex justify-center py-12">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
+    </div>
+
+    <div v-else-if="campaigns.length === 0" class="text-center py-12 text-gray-500">
+      <UIcon name="i-heroicons-book-open" class="text-4xl mb-3" />
+      <p>Aucune campagne. Créez-en une pour commencer !</p>
+    </div>
+
+    <div v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <UCard
+        v-for="campaign in campaigns"
+        :key="campaign.id"
+        class="hover:ring-2 hover:ring-primary-500 transition cursor-pointer"
+        @click="navigateTo(`/gm/campaigns/${campaign.id}`)"
+      >
+        <div class="flex items-start justify-between">
+          <div class="flex-1 min-w-0">
+            <h3 class="font-semibold text-lg truncate">{{ campaign.name }}</h3>
+            <p v-if="campaign.description" class="text-sm text-gray-400 mt-1 line-clamp-2">
+              {{ campaign.description }}
+            </p>
+            <p class="text-xs text-gray-500 mt-2">
+              {{ new Date(campaign.created_at).toLocaleDateString('fr-FR') }}
+            </p>
+          </div>
+          <UBadge color="neutral" variant="soft" class="shrink-0 ml-2">
+            {{ campaign.system }}
+          </UBadge>
+        </div>
+      </UCard>
+    </div>
+  </div>
+</template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="min-h-screen flex flex-col items-center justify-center gap-8 p-6">
+    <div class="text-center">
+      <h1 class="text-4xl font-bold text-gray-100 mb-2">Compagnon JdR</h1>
+      <p class="text-gray-400">Aide à la gestion de campagne pour The One Ring</p>
+    </div>
+
+    <div class="flex flex-col sm:flex-row gap-4 w-full max-w-md">
+      <UButton
+        to="/gm"
+        size="xl"
+        class="flex-1 justify-center"
+        color="primary"
+        icon="i-heroicons-shield-check"
+      >
+        Espace MJ
+      </UButton>
+
+      <UButton
+        to="/player/join"
+        size="xl"
+        class="flex-1 justify-center"
+        color="neutral"
+        variant="outline"
+        icon="i-heroicons-user-group"
+      >
+        Rejoindre une partie
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'minimal' })
+
+const supabase = useSupabaseClient()
+const router = useRouter()
+
+const email = ref('')
+const password = ref('')
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+async function login() {
+  loading.value = true
+  error.value = null
+
+  const { error: err } = await supabase.auth.signInWithPassword({
+    email: email.value,
+    password: password.value,
+  })
+
+  if (err) {
+    error.value = err.message
+  } else {
+    await router.push('/gm')
+  }
+  loading.value = false
+}
+
+// Rediriger si déjà connecté
+const user = useSupabaseUser()
+watchEffect(() => {
+  if (user.value) router.push('/gm')
+})
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center p-6">
+    <UCard class="w-full max-w-sm">
+      <template #header>
+        <div class="text-center">
+          <h2 class="text-xl font-bold">Connexion Maître du Jeu</h2>
+          <p class="text-sm text-gray-400 mt-1">Accès réservé au MJ</p>
+        </div>
+      </template>
+
+      <form class="space-y-4" @submit.prevent="login">
+        <UFormGroup label="Email">
+          <UInput
+            v-model="email"
+            type="email"
+            placeholder="mj@exemple.com"
+            autocomplete="email"
+            required
+          />
+        </UFormGroup>
+
+        <UFormGroup label="Mot de passe">
+          <UInput
+            v-model="password"
+            type="password"
+            autocomplete="current-password"
+            required
+          />
+        </UFormGroup>
+
+        <UAlert
+          v-if="error"
+          color="red"
+          variant="soft"
+          :title="error"
+          icon="i-heroicons-exclamation-circle"
+        />
+
+        <UButton
+          type="submit"
+          block
+          :loading="loading"
+        >
+          Se connecter
+        </UButton>
+      </form>
+
+      <template #footer>
+        <UButton to="/" variant="ghost" size="sm" icon="i-heroicons-arrow-left">
+          Retour à l'accueil
+        </UButton>
+      </template>
+    </UCard>
+  </div>
+</template>

--- a/app/pages/player/join.vue
+++ b/app/pages/player/join.vue
@@ -26,8 +26,10 @@ async function lookupSession() {
 }
 
 async function handleJoin() {
-  if (!joinCode.value.trim() || !playerName.value.trim()) return
-  const ok = await join(joinCode.value, playerName.value)
+  const code = joinCode.value.trim()
+  const name = playerName.value.trim()
+  if (!code || !name) return
+  const ok = await join(code, name)
   if (ok) {
     await navigateTo('/player/scene')
   }
@@ -83,7 +85,7 @@ async function handleJoin() {
           type="submit"
           block
           :loading="loading"
-          :disabled="!joinCode || !playerName"
+          :disabled="!joinCode.trim() || !playerName.trim()"
         >
           Rejoindre la partie
         </UButton>

--- a/app/pages/player/join.vue
+++ b/app/pages/player/join.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'minimal' })
+
+const { join, loading, error } = usePlayerSession()
+
+const joinCode = ref('')
+const playerName = ref('')
+
+// Pré-remplir le code depuis l'URL si présent (?code=XK7P2M)
+const route = useRoute()
+if (route.query.code) {
+  joinCode.value = String(route.query.code).toUpperCase()
+}
+
+// Prévisualisation de la session
+const sessionPreview = ref<{ id: string; status: string; campaign: { name: string } } | null>(null)
+const previewLoading = ref(false)
+
+async function lookupSession() {
+  const code = joinCode.value.trim().toUpperCase()
+  if (code.length < 6) { sessionPreview.value = null; return }
+
+  previewLoading.value = true
+  sessionPreview.value = await $fetch(`/api/session/${code}`).catch(() => null) as typeof sessionPreview.value
+  previewLoading.value = false
+}
+
+async function handleJoin() {
+  if (!joinCode.value.trim() || !playerName.value.trim()) return
+  const ok = await join(joinCode.value, playerName.value)
+  if (ok) {
+    await navigateTo('/player/scene')
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center p-6">
+    <UCard class="w-full max-w-sm">
+      <template #header>
+        <div class="text-center">
+          <h2 class="text-xl font-bold">Rejoindre une session</h2>
+          <p class="text-sm text-gray-400 mt-1">Entrez le code fourni par votre MJ</p>
+        </div>
+      </template>
+
+      <form class="space-y-4" @submit.prevent="handleJoin">
+        <UFormGroup label="Code de session">
+          <UInput
+            v-model="joinCode"
+            placeholder="XK7P2M"
+            maxlength="6"
+            class="font-mono text-center text-lg tracking-widest uppercase"
+            @input="joinCode = joinCode.toUpperCase(); lookupSession()"
+          />
+        </UFormGroup>
+
+        <!-- Prévisualisation campagne -->
+        <div v-if="previewLoading" class="text-center text-sm text-gray-500">
+          <UIcon name="i-heroicons-arrow-path" class="animate-spin" /> Vérification...
+        </div>
+        <UAlert
+          v-else-if="sessionPreview"
+          color="green"
+          variant="soft"
+          :title="`Campagne : ${sessionPreview.campaign.name}`"
+          icon="i-heroicons-check-circle"
+        />
+
+        <UFormGroup label="Votre prénom / pseudo">
+          <UInput v-model="playerName" placeholder="Bilbon" />
+        </UFormGroup>
+
+        <UAlert
+          v-if="error"
+          color="red"
+          variant="soft"
+          :title="error"
+          icon="i-heroicons-exclamation-circle"
+        />
+
+        <UButton
+          type="submit"
+          block
+          :loading="loading"
+          :disabled="!joinCode || !playerName"
+        >
+          Rejoindre la partie
+        </UButton>
+      </form>
+
+      <template #footer>
+        <UButton to="/" variant="ghost" size="sm" icon="i-heroicons-arrow-left">
+          Retour
+        </UButton>
+      </template>
+    </UCard>
+  </div>
+</template>

--- a/app/pages/player/scene.vue
+++ b/app/pages/player/scene.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'player-session' })
+
+const {
+  session,
+  activeScene,
+  sceneEntities,
+  playerName,
+  selectedCharacter,
+  availableCharacters,
+  restore,
+  clearSession,
+  subscribeToSessionUpdates,
+} = usePlayerSession()
+
+const showCharacterSheet = ref(false)
+const restored = ref(false)
+let unsubscribe: (() => void) | null = null
+
+onMounted(async () => {
+  // Restaurer la session depuis localStorage
+  const ok = await restore()
+  if (!ok) {
+    await navigateTo('/player/join')
+    return
+  }
+  restored.value = true
+  unsubscribe = subscribeToSessionUpdates()
+})
+
+onUnmounted(() => { unsubscribe?.() })
+
+async function leave() {
+  clearSession()
+  await navigateTo('/')
+}
+
+const enemies = computed(() =>
+  sceneEntities.value.filter(e => e.type === 'enemy'),
+)
+const items = computed(() =>
+  sceneEntities.value.filter(e => e.type === 'item'),
+)
+const npcs = computed(() =>
+  sceneEntities.value.filter(e => e.type === 'npc'),
+)
+</script>
+
+<template>
+  <div class="min-h-screen flex flex-col bg-gray-950 text-gray-100">
+    <!-- Barre de status -->
+    <div class="flex items-center justify-between px-4 py-2 bg-gray-900 border-b border-gray-800">
+      <div class="flex items-center gap-2 text-sm">
+        <UIcon name="i-heroicons-user-circle" class="text-gray-400" />
+        <span>{{ playerName }}</span>
+        <span v-if="selectedCharacter" class="text-primary-400">— {{ selectedCharacter.name }}</span>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <UBadge
+          v-if="session"
+          :color="session.status === 'active' ? 'green' : 'yellow'"
+          variant="soft"
+          size="xs"
+        >
+          {{ session.status === 'active' ? 'Session active' : 'En attente...' }}
+        </UBadge>
+
+        <UButton
+          v-if="selectedCharacter"
+          size="xs"
+          variant="soft"
+          icon="i-heroicons-identification"
+          @click="showCharacterSheet = true"
+        >
+          Feuille de perso
+        </UButton>
+
+        <UButton size="xs" variant="ghost" color="red" @click="leave">
+          Quitter
+        </UButton>
+      </div>
+    </div>
+
+    <!-- Contenu principal -->
+    <div class="flex-1 flex flex-col">
+      <!-- Scène active -->
+      <div v-if="activeScene" class="flex-1 flex flex-col">
+        <div class="px-4 py-2 bg-gray-900/50 border-b border-gray-800 text-sm">
+          <span class="text-gray-400">Scène active :</span>
+          <span class="ml-2 font-medium">{{ activeScene.name }}</span>
+          <p v-if="activeScene.description" class="text-gray-500 text-xs mt-0.5">
+            {{ activeScene.description }}
+          </p>
+        </div>
+
+        <!-- Battlemap -->
+        <div class="relative flex-1 bg-gray-950 overflow-hidden min-h-64">
+          <img
+            v-if="activeScene.battlemap_url"
+            :src="activeScene.battlemap_url"
+            class="w-full h-full object-contain"
+            alt="Battlemap"
+          >
+          <div v-else class="absolute inset-0 flex items-center justify-center text-gray-700">
+            <div class="text-center">
+              <UIcon name="i-heroicons-map" class="text-5xl mb-2" />
+              <p>Le MJ n'a pas encore chargé de carte pour cette scène.</p>
+            </div>
+          </div>
+
+          <!-- Tokens des entités sur la map -->
+          <PlayerEntityToken
+            v-for="entity in sceneEntities"
+            :key="entity.id"
+            :entity="entity"
+          />
+        </div>
+
+        <!-- Panneau entités -->
+        <div v-if="sceneEntities.length > 0" class="bg-gray-900 border-t border-gray-800 p-4">
+          <div class="grid gap-4 sm:grid-cols-3">
+            <!-- Ennemis -->
+            <div v-if="enemies.length > 0">
+              <p class="text-xs uppercase text-red-400 font-semibold mb-2">
+                Ennemis ({{ enemies.length }})
+              </p>
+              <div class="space-y-1">
+                <PlayerEnemyCard v-for="e in enemies" :key="e.id" :entity="e" />
+              </div>
+            </div>
+
+            <!-- PNJ -->
+            <div v-if="npcs.length > 0">
+              <p class="text-xs uppercase text-blue-400 font-semibold mb-2">
+                PNJ ({{ npcs.length }})
+              </p>
+              <div class="space-y-1">
+                <PlayerEntityCard v-for="e in npcs" :key="e.id" :entity="e" />
+              </div>
+            </div>
+
+            <!-- Objets -->
+            <div v-if="items.length > 0">
+              <p class="text-xs uppercase text-yellow-400 font-semibold mb-2">
+                Objets ({{ items.length }})
+              </p>
+              <div class="space-y-1">
+                <PlayerEntityCard v-for="e in items" :key="e.id" :entity="e" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- En attente de scène -->
+      <div v-else class="flex-1 flex items-center justify-center text-gray-600">
+        <div class="text-center">
+          <UIcon name="i-heroicons-clock" class="text-5xl mb-3" />
+          <p class="text-lg">En attente que le MJ lance une scène…</p>
+          <p class="text-sm mt-1">La page se mettra à jour automatiquement.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Feuille de perso en plein écran -->
+    <USlideover v-model="showCharacterSheet" side="right" class="w-full max-w-3xl">
+      <template #header>
+        <div class="flex items-center justify-between">
+          <h2 class="font-bold text-lg">{{ selectedCharacter?.name }}</h2>
+          <UButton variant="ghost" icon="i-heroicons-x-mark" @click="showCharacterSheet = false" />
+        </div>
+      </template>
+      <PlayerCharacterSheet
+        v-if="selectedCharacter"
+        :character="selectedCharacter"
+        class="p-4"
+      />
+    </USlideover>
+  </div>
+</template>

--- a/app/pages/player/sheet.vue
+++ b/app/pages/player/sheet.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+/**
+ * Vue feuille de personnage en plein écran pour affichage sur un écran dédié.
+ * Ex: le joueur ouvre cet onglet sur son téléphone ou une tablette.
+ */
+definePageMeta({ middleware: 'player-session', layout: 'fullscreen' })
+
+const { selectedCharacter, playerName, restore } = usePlayerSession()
+
+onMounted(async () => {
+  const ok = await restore()
+  if (!ok) await navigateTo('/player/join')
+})
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-950 text-gray-100 overflow-auto">
+    <div v-if="!selectedCharacter" class="flex items-center justify-center min-h-screen text-gray-600">
+      <div class="text-center">
+        <UIcon name="i-heroicons-identification" class="text-5xl mb-3" />
+        <p>Aucun personnage sélectionné.</p>
+        <UButton class="mt-4" to="/player/scene" variant="ghost">
+          Retour à la scène
+        </UButton>
+      </div>
+    </div>
+
+    <div v-else class="p-4">
+      <!-- Header compact -->
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h1 class="text-2xl font-bold">{{ selectedCharacter.name }}</h1>
+          <p class="text-gray-400 text-sm">{{ playerName }}</p>
+        </div>
+        <UButton to="/player/scene" variant="ghost" size="sm" icon="i-heroicons-arrow-left">
+          Retour
+        </UButton>
+      </div>
+
+      <PlayerCharacterSheet :character="selectedCharacter" />
+    </div>
+  </div>
+</template>

--- a/app/server/api/session/[code].get.ts
+++ b/app/server/api/session/[code].get.ts
@@ -1,0 +1,28 @@
+import { useSupabaseAdmin } from '~/server/utils/supabaseAdmin'
+
+/**
+ * GET /api/session/:code
+ * Retourne les infos publiques d'une session (nom de campagne, statut).
+ * Utilisé sur la page /player/join pour prévisualiser avant de rejoindre.
+ */
+export default defineEventHandler(async (event) => {
+  const code = getRouterParam(event, 'code')?.toUpperCase()
+
+  if (!code) {
+    throw createError({ statusCode: 400, message: 'Code requis' })
+  }
+
+  const admin = useSupabaseAdmin()
+  const { data, error } = await admin
+    .from('sessions')
+    .select('id, status, join_code, campaign:campaigns(name, system)')
+    .eq('join_code', code)
+    .neq('status', 'ended')
+    .single()
+
+  if (error || !data) {
+    throw createError({ statusCode: 404, message: 'Session introuvable ou terminée' })
+  }
+
+  return data
+})

--- a/app/server/api/session/[id]/characters.get.ts
+++ b/app/server/api/session/[id]/characters.get.ts
@@ -1,0 +1,56 @@
+import { useSupabaseAdmin } from '~/server/utils/supabaseAdmin'
+
+/**
+ * GET /api/session/:id/characters?participant_id=xxx
+ * Retourne les personnages de la campagne liée à la session pour un joueur participant.
+ * Utilise le client admin pour contourner le RLS.
+ * N'expose pas `data` ni les champs sensibles — uniquement id, name, player_name.
+ */
+export default defineEventHandler(async (event) => {
+  const sessionId = getRouterParam(event, 'id')
+  const participantId = getQuery(event).participant_id as string | undefined
+
+  if (!sessionId) {
+    throw createError({ statusCode: 400, message: 'session id requis' })
+  }
+  if (!participantId) {
+    throw createError({ statusCode: 400, message: 'participant_id requis' })
+  }
+
+  const admin = useSupabaseAdmin()
+
+  // Vérifier que le participant appartient bien à cette session
+  const { data: participant, error: participantError } = await admin
+    .from('session_participants')
+    .select('id')
+    .eq('id', participantId)
+    .eq('session_id', sessionId)
+    .single()
+
+  if (participantError || !participant) {
+    throw createError({ statusCode: 403, message: 'Participant non autorisé pour cette session' })
+  }
+
+  // Récupérer la session pour obtenir le campaign_id
+  const { data: session, error: sessionError } = await admin
+    .from('sessions')
+    .select('campaign_id')
+    .eq('id', sessionId)
+    .single()
+
+  if (sessionError || !session) {
+    throw createError({ statusCode: 404, message: 'Session introuvable' })
+  }
+
+  // Récupérer les personnages de la campagne — champs publics uniquement, pas `data`
+  const { data: characters, error: charactersError } = await admin
+    .from('characters')
+    .select('id, name, player_name')
+    .eq('campaign_id', session.campaign_id)
+
+  if (charactersError) {
+    throw createError({ statusCode: 500, message: 'Erreur lors de la récupération des personnages' })
+  }
+
+  return characters ?? []
+})

--- a/app/server/api/session/[id]/state.get.ts
+++ b/app/server/api/session/[id]/state.get.ts
@@ -1,0 +1,73 @@
+import { useSupabaseAdmin } from '~/server/utils/supabaseAdmin'
+
+/**
+ * GET /api/session/:id/state?participant_id=xxx
+ * Retourne l'état de la session pour un joueur participant.
+ * Utilise le client admin pour contourner le RLS.
+ */
+export default defineEventHandler(async (event) => {
+  const sessionId = getRouterParam(event, 'id')
+  const participantId = getQuery(event).participant_id as string | undefined
+
+  if (!sessionId) {
+    throw createError({ statusCode: 400, message: 'session id requis' })
+  }
+  if (!participantId) {
+    throw createError({ statusCode: 400, message: 'participant_id requis' })
+  }
+
+  const admin = useSupabaseAdmin()
+
+  // Vérifier que le participant appartient bien à cette session
+  const { data: participant, error: participantError } = await admin
+    .from('session_participants')
+    .select('id')
+    .eq('id', participantId)
+    .eq('session_id', sessionId)
+    .single()
+
+  if (participantError || !participant) {
+    throw createError({ statusCode: 403, message: 'Participant non autorisé pour cette session' })
+  }
+
+  // Charger la session
+  const { data: session, error: sessionError } = await admin
+    .from('sessions')
+    .select('*, campaign:campaigns(*)')
+    .eq('id', sessionId)
+    .single()
+
+  if (sessionError || !session) {
+    throw createError({ statusCode: 404, message: 'Session introuvable' })
+  }
+
+  // Charger la scène active si présente
+  let active_scene = null
+  let scene_entities: unknown[] = []
+
+  if (session.active_scene_id) {
+    const { data: sceneData } = await admin
+      .from('scenes')
+      .select('*')
+      .eq('id', session.active_scene_id)
+      .single()
+
+    if (sceneData) {
+      active_scene = sceneData
+
+      const { data: entitiesData } = await admin
+        .from('scene_entities')
+        .select('*')
+        .eq('scene_id', session.active_scene_id)
+        .eq('visible_to_players', true)
+
+      scene_entities = entitiesData ?? []
+    }
+  }
+
+  return {
+    session,
+    active_scene,
+    scene_entities,
+  }
+})

--- a/app/server/api/session/create.post.ts
+++ b/app/server/api/session/create.post.ts
@@ -1,0 +1,68 @@
+import { generateJoinCode } from '~/server/utils/generateJoinCode'
+import { useSupabaseAdmin } from '~/server/utils/supabaseAdmin'
+
+/**
+ * POST /api/session/create
+ * Crée une nouvelle session pour une campagne et génère un join_code unique.
+ * Requiert une authentification MJ (cookie Supabase).
+ */
+export default defineEventHandler(async (event) => {
+  // Vérifier l'auth MJ via le token Supabase dans les cookies
+  const supabase = await useSupabaseServer(event)
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw createError({ statusCode: 401, message: 'Non authentifié' })
+  }
+
+  const body = await readBody<{ campaign_id: string }>(event)
+
+  if (!body?.campaign_id) {
+    throw createError({ statusCode: 400, message: 'campaign_id requis' })
+  }
+
+  const admin = useSupabaseAdmin()
+
+  // Vérifier que la campagne appartient au MJ
+  const { data: campaign } = await admin
+    .from('campaigns')
+    .select('id')
+    .eq('id', body.campaign_id)
+    .eq('gm_user_id', user.id)
+    .single()
+
+  if (!campaign) {
+    throw createError({ statusCode: 403, message: 'Campagne introuvable ou accès refusé' })
+  }
+
+  // Générer un code unique (retry si collision)
+  let joinCode: string
+  let attempts = 0
+  do {
+    joinCode = generateJoinCode()
+    const { data: existing } = await admin
+      .from('sessions')
+      .select('id')
+      .eq('join_code', joinCode)
+      .maybeSingle()
+
+    if (!existing) break
+    attempts++
+  } while (attempts < 5)
+
+  if (attempts >= 5) {
+    throw createError({ statusCode: 500, message: 'Impossible de générer un code unique' })
+  }
+
+  const { data: session, error } = await admin
+    .from('sessions')
+    .insert({ campaign_id: body.campaign_id, join_code: joinCode, status: 'waiting' })
+    .select('*, campaign:campaigns(*)')
+    .single()
+
+  if (error) {
+    throw createError({ statusCode: 500, message: error.message })
+  }
+
+  return session
+})

--- a/app/server/api/session/join.post.ts
+++ b/app/server/api/session/join.post.ts
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event) => {
   // Trouver la session par code
   const { data: session, error: sessionError } = await admin
     .from('sessions')
-    .select('*, campaign:campaigns(*), active_scene:scenes(*)')
+    .select('id, join_code, status, active_scene_id, campaign_id, campaign:campaigns(name, system)')
     .eq('join_code', body.join_code.toUpperCase())
     .neq('status', 'ended')
     .single()

--- a/app/server/api/session/join.post.ts
+++ b/app/server/api/session/join.post.ts
@@ -1,0 +1,66 @@
+import { useSupabaseAdmin } from '~/server/utils/supabaseAdmin'
+
+/**
+ * POST /api/session/join
+ * Permet à un joueur anonyme de rejoindre une session via son join_code.
+ * Pas d'auth requise.
+ */
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{
+    join_code: string
+    player_name: string
+    character_id?: string
+  }>(event)
+
+  if (!body?.join_code || !body?.player_name?.trim()) {
+    throw createError({ statusCode: 400, message: 'join_code et player_name requis' })
+  }
+
+  const admin = useSupabaseAdmin()
+
+  // Trouver la session par code
+  const { data: session, error: sessionError } = await admin
+    .from('sessions')
+    .select('*, campaign:campaigns(*), active_scene:scenes(*)')
+    .eq('join_code', body.join_code.toUpperCase())
+    .neq('status', 'ended')
+    .single()
+
+  if (sessionError || !session) {
+    throw createError({ statusCode: 404, message: 'Session introuvable ou terminée' })
+  }
+
+  // Si un character_id est fourni, vérifier qu'il appartient bien à cette campagne
+  if (body.character_id) {
+    const { data: character } = await admin
+      .from('characters')
+      .select('id')
+      .eq('id', body.character_id)
+      .eq('campaign_id', session.campaign_id)
+      .single()
+
+    if (!character) {
+      throw createError({ statusCode: 400, message: 'Personnage invalide pour cette session' })
+    }
+  }
+
+  // Créer le participant
+  const { data: participant, error: participantError } = await admin
+    .from('session_participants')
+    .insert({
+      session_id: session.id,
+      player_name: body.player_name.trim(),
+      character_id: body.character_id ?? null,
+    })
+    .select()
+    .single()
+
+  if (participantError) {
+    throw createError({ statusCode: 500, message: participantError.message })
+  }
+
+  return {
+    session,
+    participant_id: participant.id,
+  }
+})

--- a/app/server/utils/generateJoinCode.ts
+++ b/app/server/utils/generateJoinCode.ts
@@ -1,0 +1,9 @@
+const CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789' // sans O/0/1/I pour éviter confusions
+
+/**
+ * Génère un code de session lisible de 6 caractères.
+ * Ex: "XK7P2M"
+ */
+export function generateJoinCode(): string {
+  return Array.from({ length: 6 }, () => CHARS[Math.floor(Math.random() * CHARS.length)]).join('')
+}

--- a/app/server/utils/generateJoinCode.ts
+++ b/app/server/utils/generateJoinCode.ts
@@ -1,9 +1,11 @@
+import { randomInt } from 'node:crypto'
+
 const CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789' // sans O/0/1/I pour éviter confusions
 
 /**
  * Génère un code de session lisible de 6 caractères.
  * Ex: "XK7P2M"
  */
-export function generateJoinCode(): string {
-  return Array.from({ length: 6 }, () => CHARS[Math.floor(Math.random() * CHARS.length)]).join('')
+export function generateJoinCode(length = 6): string {
+  return Array.from({ length }, () => CHARS[randomInt(0, CHARS.length)]).join('')
 }

--- a/app/server/utils/supabaseAdmin.ts
+++ b/app/server/utils/supabaseAdmin.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js'
+
+/**
+ * Client Supabase avec la service_role key.
+ * Bypass le RLS → à utiliser uniquement côté serveur.
+ */
+export function useSupabaseAdmin() {
+  const config = useRuntimeConfig()
+  return createClient(
+    config.public.supabaseUrl,
+    config.supabaseServiceKey,
+    { auth: { persistSession: false } },
+  )
+}

--- a/app/supabase/migrations/001_initial_schema.sql
+++ b/app/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,223 @@
+-- ============================================================
+-- Compagnon JdR - Schéma initial
+-- ============================================================
+-- À exécuter dans l'éditeur SQL de Supabase (Database > SQL Editor)
+-- ou via la CLI Supabase : supabase db push
+-- ============================================================
+
+-- Extensions
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ─── Campagnes ──────────────────────────────────────────────────────────────
+CREATE TABLE campaigns (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  gm_user_id  UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  description TEXT,
+  system      TEXT NOT NULL DEFAULT 'the-one-ring',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Personnages ─────────────────────────────────────────────────────────────
+-- Le champ "data" contient la feuille de perso au format JSONB.
+-- Cela permet de changer de système sans toucher au schéma.
+CREATE TABLE characters (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id  UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  player_name  TEXT,
+  data         JSONB NOT NULL DEFAULT '{}',
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Sessions de jeu ─────────────────────────────────────────────────────────
+-- Une session = une partie en cours. Le MJ crée une session depuis une campagne,
+-- ce qui génère un join_code unique à 6 caractères pour les joueurs.
+CREATE TABLE sessions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id     UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  join_code       TEXT UNIQUE NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'waiting'
+                    CHECK (status IN ('waiting', 'active', 'ended')),
+  active_scene_id UUID,  -- FK ajouté plus bas (après scenes)
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Scènes ──────────────────────────────────────────────────────────────────
+CREATE TABLE scenes (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id   UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  description  TEXT,
+  battlemap_url TEXT,  -- URL vers Supabase Storage
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- FK différée pour éviter la dépendance circulaire sessions <-> scenes
+ALTER TABLE sessions
+  ADD CONSTRAINT sessions_active_scene_id_fkey
+  FOREIGN KEY (active_scene_id) REFERENCES scenes(id) ON DELETE SET NULL;
+
+-- ─── Entités de scène ─────────────────────────────────────────────────────────
+-- Ennemis, PNJ, objets lootés, zones de danger, etc.
+CREATE TABLE scene_entities (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scene_id            UUID NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+  type                TEXT NOT NULL CHECK (type IN ('enemy', 'npc', 'item', 'zone')),
+  name                TEXT NOT NULL,
+  data                JSONB NOT NULL DEFAULT '{}',
+  position            JSONB NOT NULL DEFAULT '{"x": 0, "y": 0}',
+  visible_to_players  BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Participants à la session ────────────────────────────────────────────────
+-- Un joueur anonyme qui rejoint avec le join_code.
+-- Il peut (ou non) être lié à un personnage de la campagne.
+CREATE TABLE session_participants (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id   UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  character_id UUID REFERENCES characters(id) ON DELETE SET NULL,
+  player_name  TEXT NOT NULL,
+  joined_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+CREATE INDEX idx_campaigns_gm ON campaigns(gm_user_id);
+CREATE INDEX idx_characters_campaign ON characters(campaign_id);
+CREATE INDEX idx_sessions_campaign ON sessions(campaign_id);
+CREATE INDEX idx_sessions_join_code ON sessions(join_code);
+CREATE INDEX idx_scenes_session ON scenes(session_id);
+CREATE INDEX idx_scene_entities_scene ON scene_entities(scene_id);
+CREATE INDEX idx_participants_session ON session_participants(session_id);
+
+-- ─── Updated_at automatique ───────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER campaigns_updated_at
+  BEFORE UPDATE ON campaigns
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER characters_updated_at
+  BEFORE UPDATE ON characters
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER sessions_updated_at
+  BEFORE UPDATE ON sessions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER scene_entities_updated_at
+  BEFORE UPDATE ON scene_entities
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─── Row Level Security (RLS) ─────────────────────────────────────────────────
+
+ALTER TABLE campaigns          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE characters         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sessions           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scenes             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scene_entities     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE session_participants ENABLE ROW LEVEL SECURITY;
+
+-- Campaigns : uniquement le MJ propriétaire
+CREATE POLICY "campaigns_gm_all"
+  ON campaigns FOR ALL
+  USING (auth.uid() = gm_user_id);
+
+-- Characters : le MJ de la campagne peut tout faire
+CREATE POLICY "characters_gm_all"
+  ON characters FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM campaigns
+      WHERE campaigns.id = characters.campaign_id
+        AND campaigns.gm_user_id = auth.uid()
+    )
+  );
+
+-- Characters : lecture anonyme via session active (pour les joueurs)
+CREATE POLICY "characters_player_read"
+  ON characters FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM sessions s
+      JOIN session_participants sp ON sp.session_id = s.id
+      WHERE s.campaign_id = characters.campaign_id
+        AND s.status = 'active'
+        AND sp.character_id = characters.id
+    )
+  );
+
+-- Sessions : le MJ peut tout faire
+CREATE POLICY "sessions_gm_all"
+  ON sessions FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM campaigns
+      WHERE campaigns.id = sessions.campaign_id
+        AND campaigns.gm_user_id = auth.uid()
+    )
+  );
+
+-- Sessions : lecture anonyme par join_code (vérifiée côté API serveur)
+-- On utilise une fonction RPC pour rejoindre, donc pas de policy SELECT public ici.
+
+-- Scenes : le MJ peut tout faire
+CREATE POLICY "scenes_gm_all"
+  ON scenes FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM sessions s
+      JOIN campaigns c ON c.id = s.campaign_id
+      WHERE s.id = scenes.session_id
+        AND c.gm_user_id = auth.uid()
+    )
+  );
+
+-- Scene entities : le MJ peut tout faire
+CREATE POLICY "scene_entities_gm_all"
+  ON scene_entities FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM scenes sc
+      JOIN sessions s ON s.id = sc.session_id
+      JOIN campaigns c ON c.id = s.campaign_id
+      WHERE sc.id = scene_entities.scene_id
+        AND c.gm_user_id = auth.uid()
+    )
+  );
+
+-- Session participants : le MJ peut lire
+CREATE POLICY "participants_gm_read"
+  ON session_participants FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM sessions s
+      JOIN campaigns c ON c.id = s.campaign_id
+      WHERE s.id = session_participants.session_id
+        AND c.gm_user_id = auth.uid()
+    )
+  );
+
+-- ─── Storage bucket pour les battlemaps ───────────────────────────────────────
+-- À créer manuellement dans Storage > New bucket : "battlemaps" (public)
+-- Ou via API :
+-- INSERT INTO storage.buckets (id, name, public) VALUES ('battlemaps', 'battlemaps', true);
+
+-- ─── Realtime ─────────────────────────────────────────────────────────────────
+-- Activer la réplication pour les tables qui nécessitent du temps réel.
+-- À faire dans Supabase Dashboard > Database > Replication, ou via :
+ALTER PUBLICATION supabase_realtime ADD TABLE sessions;
+ALTER PUBLICATION supabase_realtime ADD TABLE scenes;
+ALTER PUBLICATION supabase_realtime ADD TABLE scene_entities;
+ALTER PUBLICATION supabase_realtime ADD TABLE session_participants;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/app/types/rpg.ts
+++ b/app/types/rpg.ts
@@ -1,0 +1,206 @@
+// ─── Système de jeu ────────────────────────────────────────────────────────
+
+export type RPGSystem = 'the-one-ring'
+
+// ─── The One Ring : données de feuille de personnage ───────────────────────
+
+export interface TORAttributes {
+  strength: number
+  heart: number
+  mind: number
+}
+
+export interface TORSkill {
+  name: string
+  rank: number
+  favoured: boolean
+}
+
+export interface TORWeapon {
+  name: string
+  damage: number
+  injury: number
+  load: number
+  notes?: string
+}
+
+export interface TORArmor {
+  name: string
+  protection: number
+  load: number
+}
+
+export interface TORVirtue {
+  name: string
+  description: string
+}
+
+export interface TORReward {
+  name: string
+  description: string
+}
+
+export interface TORCharacterData {
+  // Identité
+  culture: string
+  vocation: string
+  standard_of_living: string
+  // Attributs principaux
+  attributes: TORAttributes
+  // Attributs secondaires
+  endurance_max: number
+  endurance_current: number
+  hope_max: number
+  hope_current: number
+  shadow: number
+  parry: number
+  // Compétences
+  skills_strength: TORSkill[]
+  skills_heart: TORSkill[]
+  skills_mind: TORSkill[]
+  // Équipement
+  weapons: TORWeapon[]
+  armor?: TORArmor
+  // Progression
+  experience: number
+  advancement: number
+  // Vertus & Récompenses
+  virtues: TORVirtue[]
+  rewards: TORReward[]
+  // Notes
+  notes?: string
+}
+
+// ─── Entités de base (mapping tables Supabase) ────────────────────────────
+
+export interface Campaign {
+  id: string
+  gm_user_id: string
+  name: string
+  description: string | null
+  system: RPGSystem
+  created_at: string
+  updated_at: string
+}
+
+export interface Character {
+  id: string
+  campaign_id: string
+  name: string
+  player_name: string | null
+  data: TORCharacterData
+  created_at: string
+  updated_at: string
+}
+
+export type SessionStatus = 'waiting' | 'active' | 'ended'
+
+export interface GameSession {
+  id: string
+  campaign_id: string
+  join_code: string
+  status: SessionStatus
+  active_scene_id: string | null
+  created_at: string
+  updated_at: string
+  // Relations (jointes)
+  campaign?: Campaign
+  active_scene?: Scene
+}
+
+export interface Scene {
+  id: string
+  session_id: string
+  name: string
+  description: string | null
+  battlemap_url: string | null
+  created_at: string
+}
+
+export type EntityType = 'enemy' | 'npc' | 'item' | 'zone'
+
+export interface EntityPosition {
+  x: number
+  y: number
+}
+
+export interface EnemyData {
+  endurance: number
+  endurance_max: number
+  parry: number
+  armor: number
+  hate?: number
+  hate_max?: number
+  attribute_level?: number
+  notes?: string
+}
+
+export interface ItemData {
+  description: string
+  quantity?: number
+  is_magical?: boolean
+}
+
+export interface ZoneData {
+  color: string
+  opacity: number
+  description?: string
+}
+
+export type EntityData = EnemyData | ItemData | ZoneData | Record<string, unknown>
+
+export interface SceneEntity {
+  id: string
+  scene_id: string
+  type: EntityType
+  name: string
+  data: EntityData
+  position: EntityPosition
+  visible_to_players: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface SessionParticipant {
+  id: string
+  session_id: string
+  character_id: string | null
+  player_name: string
+  joined_at: string
+  // Relations
+  character?: Character
+}
+
+// ─── Payloads API ─────────────────────────────────────────────────────────
+
+export interface CreateSessionPayload {
+  campaign_id: string
+}
+
+export interface JoinSessionPayload {
+  join_code: string
+  player_name: string
+  character_id?: string
+}
+
+export interface JoinSessionResponse {
+  session: GameSession
+  participant_id: string
+}
+
+// ─── État local session (composables) ─────────────────────────────────────
+
+export interface PlayerSessionState {
+  session: GameSession | null
+  participant_id: string | null
+  player_name: string | null
+  selected_character: Character | null
+}
+
+export interface GMSessionState {
+  session: GameSession | null
+  participants: SessionParticipant[]
+  scenes: Scene[]
+  active_scene: Scene | null
+  entities: SceneEntity[]
+}


### PR DESCRIPTION
Nouveau projet compagnon-jdr construit de zéro avec :

Stack :
- Nuxt 3 (full-stack, SSR + API routes server/)
- @nuxtjs/supabase (auth MJ + realtime + storage)
- @nuxt/ui (composants)
- TypeScript strict

Architecture :
- /pages/gm/** : interface MJ (campagnes, session live, persos)
- /pages/player/** : interface joueur (join via code, scène, feuille perso)
- /server/api/session/ : API pour créer/rejoindre une session
- /composables/ : useGMSession, usePlayerSession, useCharacter, useScene
- /middleware/ : protection routes GM (auth) + routes joueur (code session)

Base de données :
- Migration SQL complète avec RLS (campaigns, characters, sessions, scenes, scene_entities, session_participants)
- Realtime activé sur sessions, scenes, scene_entities
- Bucket Storage "battlemaps"

Fonctionnalités :
- MJ : login Supabase Auth, gestion campagnes/personnages, lancement session
- Code de session 6 caractères généré côté serveur pour les joueurs
- Scènes avec upload battlemap (Supabase Storage)
- Entités de scène (ennemis, PNJ, objets, zones) avec visibilité MJ/joueurs
- Temps réel via Supabase Realtime (remplace Socket.IO)
- Feuille de personnage The One Ring (JSONB flexible pour futurs systèmes)
- Vue joueur : scène temps réel, feuille de perso plein écran

https://claude.ai/code/session_01KCGxd5ZMC4V1kBqWCWmuaR